### PR TITLE
github: Add workflow to publish to Asset Library

### DIFF
--- a/.github/workflows/godot-asset-library.yaml
+++ b/.github/workflows/godot-asset-library.yaml
@@ -1,0 +1,21 @@
+on:
+  release:
+    types:
+      - published
+
+name: Push to Godot Asset Library
+
+jobs:
+  publish:
+    if: github.event.action == 'released'
+    runs-on: ubuntu-latest
+    name: Push new release
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Push to Godot Asset Library
+        uses: deep-entertainment/godot-asset-lib-action@v0.4.0
+        with:
+          username: ${{ secrets.GODOT_ASSET_LIBRARY_USERNAME }}
+          password: ${{ secrets.GODOT_ASSET_LIBRARY_PASSWORD }}
+          assetId: 12617


### PR DESCRIPTION
The workflow is triggered by publishing a release (which is essentially
a fancy tag). If it turns out we need to trigger it manually we could
later add workflow_dispatch.

https://phabricator.endlessm.com/T35503