### PR TITLE
Fix base class identification (for Picker)

### DIFF
--- a/addons/block_code/simple_nodes/simple_character/simple_character.gd
+++ b/addons/block_code/simple_nodes/simple_character/simple_character.gd
@@ -13,10 +13,6 @@ func get_custom_class():
 	return "SimpleCharacter"
 
 
-static func get_base_class():
-	return "CharacterBody2D"
-
-
 static func get_exposed_properties() -> Array[String]:
 	return ["position"]
 

--- a/addons/block_code/ui/picker/picker.gd
+++ b/addons/block_code/ui/picker/picker.gd
@@ -25,7 +25,7 @@ func bsd_selected(bsd: BlockScriptData):
 
 	var parent_class: String
 	if found_simple_class_script:
-		parent_class = found_simple_class_script.get_base_class()
+		parent_class = str(found_simple_class_script.get_instance_base_type())
 	else:  # Built in
 		parent_class = bsd.script_inherits
 


### PR DESCRIPTION
This is just a really small fix for an error that was happening in the pong game. For previous classes with custom blocks, like `SimpleCharacter`, you had to define a method that specified the base class so the picker would know which blocks to populate itself with.

However, there is a function `script.get_instance_base_type()` that gets this automatically from whichever class the script extends. Much nicer than having to define a function for this every time.