### PR TITLE
block_code/picker: Store the AudioStreamPlayer in the VAR_DICT

### DIFF
--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -237,13 +237,13 @@ static func get_general_categories() -> Array[BlockCategory]:
 	b = BLOCKS["statement_block"].instantiate()
 	b.block_type = Types.BlockType.EXECUTE
 	b.block_format = "Load file {file_path: STRING} as sound {name: STRING}"
-	b.statement = "var sound = AudioStreamPlayer.new()\nsound.name = {name}\nsound.set_stream(load({file_path}))\nadd_child(sound)\nsound.set_owner(self)"
+	b.statement = "VAR_DICT[{name}] = AudioStreamPlayer.new()\nVAR_DICT[{name}].name = {name}\nVAR_DICT[{name}].set_stream(load({file_path}))\nadd_child(VAR_DICT[{name}])"
 	sound_list.append(b)
 
 	b = BLOCKS["statement_block"].instantiate()
 	b.block_type = Types.BlockType.EXECUTE
 	b.block_format = "Play the sound {name: STRING} with Volume dB {db: FLOAT} and Pitch Scale {pitch: FLOAT}"
-	b.statement = "var sound = find_child({name})\nsound.volume_db = {db}\nsound.pitch_scale = {pitch}\nsound.play()"
+	b.statement = "VAR_DICT[{name}].volume_db = {db}\nVAR_DICT[{name}].pitch_scale = {pitch}\nVAR_DICT[{name}].play()"
 	sound_list.append(b)
 
 	var sound_category: BlockCategory = BlockCategory.new("Sound", sound_list, Color("e30fc0"))

--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -244,6 +244,7 @@ static func get_general_categories() -> Array[BlockCategory]:
 	b.block_type = Types.BlockType.EXECUTE
 	b.block_format = "Play the sound {name: STRING} with Volume dB {db: FLOAT} and Pitch Scale {pitch: FLOAT}"
 	b.statement = "VAR_DICT[{name}].volume_db = {db}\nVAR_DICT[{name}].pitch_scale = {pitch}\nVAR_DICT[{name}].play()"
+	b.defaults = {"db": "0.0", "pitch": "1.0"}
 	sound_list.append(b)
 
 	var sound_category: BlockCategory = BlockCategory.new("Sound", sound_list, Color("e30fc0"))

--- a/pong_game/ball.tscn
+++ b/pong_game/ball.tscn
@@ -1,9 +1,7 @@
-[gd_scene load_steps=7 format=3 uid="uid://c7l70grmkauij"]
+[gd_scene load_steps=5 format=3 uid="uid://c7l70grmkauij"]
 
 [ext_resource type="Script" path="res://pong_game/ball.gd" id="1_vdrab"]
 [ext_resource type="Texture2D" uid="uid://bcgr5amsq3jfl" path="res://pong_game/ball.png" id="2_xkrmm"]
-[ext_resource type="AudioStream" uid="uid://bc7jd3d8m5spt" path="res://pong_game/wall_hit.ogg" id="3_mjbsd"]
-[ext_resource type="AudioStream" uid="uid://jk0oapxjw354" path="res://pong_game/paddle_hit.ogg" id="4_skr8k"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_c3m63"]
 friction = 0.0
@@ -31,11 +29,3 @@ shape = SubResource("CircleShape2D_sntrn")
 [node name="Sprite2D" type="Sprite2D" parent="."]
 unique_name_in_owner = true
 texture = ExtResource("2_xkrmm")
-
-[node name="WallAudioStreamPlayer" type="AudioStreamPlayer" parent="."]
-stream = ExtResource("3_mjbsd")
-
-[node name="PaddleAudioStreamPlayer" type="AudioStreamPlayer" parent="."]
-stream = ExtResource("4_skr8k")
-
-[connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/pong_game/pong_game.tscn
+++ b/pong_game/pong_game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=33 format=3 uid="uid://tf7b8c64ecc0"]
+[gd_scene load_steps=61 format=3 uid="uid://tf7b8c64ecc0"]
 
 [ext_resource type="PackedScene" uid="uid://s7enbp56f256" path="res://pong_game/paddle.tscn" id="1_1k5k2"]
 [ext_resource type="Script" path="res://pong_game/pong_game.gd" id="1_bjkc8"]
@@ -95,6 +95,210 @@ func _process(delta):
 
 "
 
+[sub_resource type="Resource" id="Resource_w7llf"]
+script = ExtResource("5_wr38c")
+block_class = &"StatementBlock"
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.890196, 0.0588235, 0.752941, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["block_format", "Load file {file_path: STRING} as sound {name: STRING}"], ["statement", "VAR_DICT[{name}] = AudioStreamPlayer.new()
+VAR_DICT[{name}].name = {name}
+VAR_DICT[{name}].set_stream(load({file_path}))
+add_child(VAR_DICT[{name}])"], ["defaults", {}], ["param_input_strings", {
+"file_path": "res://pong_game/wall_hit.ogg",
+"name": "wall_hit"
+}]]
+
+[sub_resource type="Resource" id="Resource_dvwua"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_w7llf")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_rrqjv"]
+script = ExtResource("5_wr38c")
+block_class = &"StatementBlock"
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.890196, 0.0588235, 0.752941, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["block_format", "Load file {file_path: STRING} as sound {name: STRING}"], ["statement", "VAR_DICT[{name}] = AudioStreamPlayer.new()
+VAR_DICT[{name}].name = {name}
+VAR_DICT[{name}].set_stream(load({file_path}))
+add_child(VAR_DICT[{name}])"], ["defaults", {}], ["param_input_strings", {
+"file_path": "res://pong_game/paddle_hit.ogg",
+"name": "paddle_hit"
+}]]
+
+[sub_resource type="Resource" id="Resource_c4ce1"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_rrqjv")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_dvwua")]]
+
+[sub_resource type="Resource" id="Resource_r8cwo"]
+script = ExtResource("5_wr38c")
+block_class = &"EntryBlock"
+serialized_props = [["block_name", "ready_block"], ["label", "EntryBlock"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 1], ["position", Vector2(54, 47)], ["block_format", "On Ready"], ["statement", "func _ready():"], ["defaults", {}], ["param_input_strings", {}], ["signal_name", ""]]
+
+[sub_resource type="Resource" id="Resource_pgiuj"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_r8cwo")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_c4ce1")]]
+
+[sub_resource type="Resource" id="Resource_lkcfx"]
+script = ExtResource("5_wr38c")
+block_class = &"ParameterBlock"
+serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["defaults", {}], ["variant_type", 22], ["param_input_strings", {}]]
+
+[sub_resource type="Resource" id="Resource_vne13"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_lkcfx")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_mkixe"]
+script = ExtResource("5_wr38c")
+block_class = &"ParameterBlock"
+serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["defaults", {}], ["variant_type", 22], ["param_input_strings", {}]]
+
+[sub_resource type="Resource" id="Resource_ja8qr"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_mkixe")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_6233g"]
+script = ExtResource("5_wr38c")
+block_class = &"ParameterBlock"
+serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["block_format", "Is {node: NODE_PATH} in group {group: STRING}"], ["statement", "get_node({node}).is_in_group({group})"], ["defaults", {}], ["variant_type", 1], ["param_input_strings", {
+"group": "paddles",
+"node": ""
+}]]
+
+[sub_resource type="Resource" id="Resource_ar1vw"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_6233g")
+path_child_pairs = [[NodePath("MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_ja8qr")]]
+
+[sub_resource type="Resource" id="Resource_hbwws"]
+script = ExtResource("5_wr38c")
+block_class = &"StatementBlock"
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.890196, 0.0588235, 0.752941, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["block_format", "Play the sound {name: STRING} with Volume dB {db: FLOAT} and Pitch Scale {pitch: FLOAT}"], ["statement", "VAR_DICT[{name}].volume_db = {db}
+VAR_DICT[{name}].pitch_scale = {pitch}
+VAR_DICT[{name}].play()"], ["defaults", {}], ["param_input_strings", {
+"db": "0.0",
+"name": "paddle_hit",
+"pitch": "1.0"
+}]]
+
+[sub_resource type="Resource" id="Resource_xb342"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_hbwws")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_y0dfo"]
+script = ExtResource("5_wr38c")
+block_class = &"ParameterBlock"
+serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["block_format", "body"], ["statement", "body"], ["defaults", {}], ["variant_type", 22], ["param_input_strings", {}]]
+
+[sub_resource type="Resource" id="Resource_lkc6w"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_y0dfo")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_ou8eo"]
+script = ExtResource("5_wr38c")
+block_class = &"ParameterBlock"
+serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["block_format", "Is {node: NODE_PATH} in group {group: STRING}"], ["statement", "get_node({node}).is_in_group({group})"], ["defaults", {}], ["variant_type", 1], ["param_input_strings", {
+"group": "walls",
+"node": ""
+}]]
+
+[sub_resource type="Resource" id="Resource_jp11d"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_ou8eo")
+path_child_pairs = [[NodePath("MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_lkc6w")]]
+
+[sub_resource type="Resource" id="Resource_rer42"]
+script = ExtResource("5_wr38c")
+block_class = &"StatementBlock"
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.890196, 0.0588235, 0.752941, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["block_format", "Play the sound {name: STRING} with Volume dB {db: FLOAT} and Pitch Scale {pitch: FLOAT}"], ["statement", "VAR_DICT[{name}].volume_db = {db}
+VAR_DICT[{name}].pitch_scale = {pitch}
+VAR_DICT[{name}].play()"], ["defaults", {}], ["param_input_strings", {
+"db": "0.0",
+"name": "wall_hit",
+"pitch": "1.0"
+}]]
+
+[sub_resource type="Resource" id="Resource_nanxw"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_rer42")
+path_child_pairs = []
+
+[sub_resource type="Resource" id="Resource_8ljc2"]
+script = ExtResource("5_wr38c")
+block_class = &"ControlBlock"
+serialized_props = [["block_name", "control_block"], ["label", "Control Block"], ["color", Color(1, 0.678431, 0.462745, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["block_formats", ["if    {condition: BOOL}"]], ["statements", ["if {condition}:"]], ["defaults", {}], ["param_input_strings_array", [{
+"condition": true
+}]]]
+
+[sub_resource type="Resource" id="Resource_ewj1y"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_8ljc2")
+path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_jp11d")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_nanxw")]]
+
+[sub_resource type="Resource" id="Resource_nwfcj"]
+script = ExtResource("5_wr38c")
+block_class = &"ControlBlock"
+serialized_props = [["block_name", "control_block"], ["label", "Control Block"], ["color", Color(1, 0.678431, 0.462745, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["block_formats", ["if    {condition: BOOL}"]], ["statements", ["if {condition}:"]], ["defaults", {}], ["param_input_strings_array", [{
+"condition": true
+}]]]
+
+[sub_resource type="Resource" id="Resource_up363"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_nwfcj")
+path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_ar1vw")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_xb342")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_ewj1y")]]
+
+[sub_resource type="Resource" id="Resource_uuy53"]
+script = ExtResource("5_wr38c")
+block_class = &"EntryBlock"
+serialized_props = [["block_name", "entry_block"], ["label", "EntryBlock"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 1], ["position", Vector2(54, 207)], ["block_format", "On [body: NODE_PATH] entered"], ["statement", "func _on_body_entered(_body: Node):
+	var body: NodePath = _body.get_path()"], ["defaults", {}], ["param_input_strings", {
+"body": ""
+}], ["signal_name", "body_entered"]]
+
+[sub_resource type="Resource" id="Resource_6ki5d"]
+script = ExtResource("4_qtggh")
+serialized_block = SubResource("Resource_uuy53")
+path_child_pairs = [[NodePath("VBoxContainer/TopMarginContainer/MarginContainer/HBoxContainer/ParameterInput0/SnapPoint"), SubResource("Resource_vne13")], [NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_up363")]]
+
+[sub_resource type="Resource" id="Resource_7j4bl"]
+script = ExtResource("6_ppdc3")
+array = Array[ExtResource("4_qtggh")]([SubResource("Resource_pgiuj"), SubResource("Resource_6ki5d")])
+
+[sub_resource type="Resource" id="Resource_gkcqr"]
+script = ExtResource("7_uuuue")
+script_inherits = "RigidBody2D"
+block_trees = SubResource("Resource_7j4bl")
+generated_script = "extends RigidBody2D
+
+var VAR_DICT := {}
+
+func _ready():
+	VAR_DICT['paddle_hit'] = AudioStreamPlayer.new()
+	VAR_DICT['paddle_hit'].name = 'paddle_hit'
+	VAR_DICT['paddle_hit'].set_stream(load('res://pong_game/paddle_hit.ogg'))
+	add_child(VAR_DICT['paddle_hit'])
+	VAR_DICT['wall_hit'] = AudioStreamPlayer.new()
+	VAR_DICT['wall_hit'].name = 'wall_hit'
+	VAR_DICT['wall_hit'].set_stream(load('res://pong_game/wall_hit.ogg'))
+	add_child(VAR_DICT['wall_hit'])
+
+func _on_body_entered(_body: Node):
+	var body: NodePath = _body.get_path()
+	if get_node(body).is_in_group('paddles'):
+		VAR_DICT['paddle_hit'].volume_db = 0.0
+		VAR_DICT['paddle_hit'].pitch_scale = 1.0
+		VAR_DICT['paddle_hit'].play()
+	if get_node(body).is_in_group('walls'):
+		VAR_DICT['wall_hit'].volume_db = 0.0
+		VAR_DICT['wall_hit'].pitch_scale = 1.0
+		VAR_DICT['wall_hit'].play()
+
+func _init():
+	body_entered.connect(_on_body_entered)
+"
+
 [sub_resource type="Resource" id="Resource_ve47i"]
 script = ExtResource("5_wr38c")
 block_class = &"StatementBlock"
@@ -172,6 +376,10 @@ block_script = SubResource("Resource_52r02")
 modulate = Color(0.511, 0.362, 0.972, 1)
 position = Vector2(960, 544)
 linear_velocity = Vector2(353.553, 353.553)
+
+[node name="BlockCode" type="Node" parent="Ball"]
+script = ExtResource("3_6jaq8")
+block_script = SubResource("Resource_gkcqr")
 
 [node name="BallSpawnArea" parent="." groups=["ball_spawn_area"] instance=ExtResource("10_5vs1t")]
 position = Vector2(960, 544)

--- a/pong_game/space.tscn
+++ b/pong_game/space.tscn
@@ -25,7 +25,7 @@ patch_margin_bottom = 64
 axis_stretch_horizontal = 2
 axis_stretch_vertical = 2
 
-[node name="Walls" type="RigidBody2D" parent="."]
+[node name="Walls" type="RigidBody2D" parent="." groups=["walls"]]
 collision_layer = 4
 collision_mask = 3
 collision_priority = 10.0

--- a/test_game/test_game.tscn
+++ b/test_game/test_game.tscn
@@ -8,142 +8,140 @@
 [ext_resource type="Script" path="res://addons/block_code/block_script_data/block_script_data.gd" id="5_q37d3"]
 [ext_resource type="Texture2D" uid="uid://dr8e0tvfxjy1f" path="res://icon.svg" id="7_a27o8"]
 
-[sub_resource type="Resource" id="Resource_uwmna"]
+[sub_resource type="Resource" id="Resource_8cj5x"]
 script = ExtResource("3_dpt5n")
 block_class = &"StatementBlock"
-serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.890196, 0.0588235, 0.752941, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["block_format", "Load file {file_path: STRING} as sound {name: STRING}"], ["statement", "var sound = AudioStreamPlayer.new()
-sound.name = {name}
-sound.set_stream(load({file_path}))
-add_child(sound)
-sound.set_owner(self)"], ["param_input_strings", {
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.890196, 0.0588235, 0.752941, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["block_format", "Load file {file_path: STRING} as sound {name: STRING}"], ["statement", "VAR_DICT[{name}] = AudioStreamPlayer.new()
+VAR_DICT[{name}].name = {name}
+VAR_DICT[{name}].set_stream(load({file_path}))
+add_child(VAR_DICT[{name}])"], ["defaults", {}], ["param_input_strings", {
 "file_path": "res://test_game/test_audio.ogg",
 "name": "testsound"
 }]]
 
-[sub_resource type="Resource" id="Resource_5jnoq"]
+[sub_resource type="Resource" id="Resource_cejx6"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_uwmna")
+serialized_block = SubResource("Resource_8cj5x")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_2niad"]
+[sub_resource type="Resource" id="Resource_mwuch"]
 script = ExtResource("3_dpt5n")
 block_class = &"StatementBlock"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Send signal {signal: STRING} to group {group: STRING}"], ["statement", "var signal_manager = get_tree().root.get_node_or_null(\"SignalManager\")
 if signal_manager:
-	signal_manager.broadcast_signal({group}, {signal})"], ["param_input_strings", {
+	signal_manager.broadcast_signal({group}, {signal})"], ["defaults", {}], ["param_input_strings", {
 "group": "Player",
 "signal": "will_hi"
 }]]
 
-[sub_resource type="Resource" id="Resource_hb8ii"]
+[sub_resource type="Resource" id="Resource_mc5xr"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_2niad")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_5jnoq")]]
+serialized_block = SubResource("Resource_mwuch")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_cejx6")]]
 
-[sub_resource type="Resource" id="Resource_nfmdk"]
+[sub_resource type="Resource" id="Resource_kxr1w"]
 script = ExtResource("3_dpt5n")
 block_class = &"StatementBlock"
-serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Add to group {group: STRING}"], ["statement", "add_to_group({group})"], ["param_input_strings", {
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.941176, 0.764706, 0, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Add to group {group: STRING}"], ["statement", "add_to_group({group})"], ["defaults", {}], ["param_input_strings", {
 "group": "Player"
 }]]
 
-[sub_resource type="Resource" id="Resource_kiuvv"]
+[sub_resource type="Resource" id="Resource_mtxrj"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_nfmdk")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_hb8ii")]]
+serialized_block = SubResource("Resource_kxr1w")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_mc5xr")]]
 
-[sub_resource type="Resource" id="Resource_4xja7"]
+[sub_resource type="Resource" id="Resource_qkcck"]
 script = ExtResource("3_dpt5n")
 block_class = &"StatementBlock"
-serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["param_input_strings", {
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.6, 0.537255, 0.87451, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "print {text: STRING}"], ["statement", "print({text})"], ["defaults", {}], ["param_input_strings", {
 "text": "Hi Manuel!"
 }]]
 
-[sub_resource type="Resource" id="Resource_u6g84"]
+[sub_resource type="Resource" id="Resource_js726"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_4xja7")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_kiuvv")]]
+serialized_block = SubResource("Resource_qkcck")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_mtxrj")]]
 
-[sub_resource type="Resource" id="Resource_6xoyl"]
+[sub_resource type="Resource" id="Resource_5fs1k"]
 script = ExtResource("3_dpt5n")
 block_class = &"EntryBlock"
-serialized_props = [["block_name", "ready_block"], ["label", "EntryBlock"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 1], ["position", Vector2(84, 33)], ["block_format", "On Ready"], ["statement", "func _ready():"], ["param_input_strings", {}]]
+serialized_props = [["block_name", "ready_block"], ["label", "EntryBlock"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 1], ["position", Vector2(84, 33)], ["block_format", "On Ready"], ["statement", "func _ready():"], ["defaults", {}], ["param_input_strings", {}], ["signal_name", ""]]
 
-[sub_resource type="Resource" id="Resource_xdg8y"]
+[sub_resource type="Resource" id="Resource_7blgt"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_6xoyl")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_u6g84")]]
+serialized_block = SubResource("Resource_5fs1k")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_js726")]]
 
-[sub_resource type="Resource" id="Resource_7ot84"]
+[sub_resource type="Resource" id="Resource_8x341"]
 script = ExtResource("3_dpt5n")
 block_class = &"ParameterBlock"
-serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["block_format", "Is action ui_right pressed"], ["statement", "Input.is_action_pressed(\"ui_right\")"], ["param_input_strings", {}]]
+serialized_props = [["block_name", "parameter_block"], ["label", "Param"], ["color", Color(0.439216, 0.501961, 0.564706, 1)], ["block_type", 3], ["position", Vector2(0, 0)], ["block_format", "Is action ui_right pressed"], ["statement", "Input.is_action_pressed(\"ui_right\")"], ["defaults", {}], ["variant_type", 0], ["param_input_strings", {}]]
 
-[sub_resource type="Resource" id="Resource_xyinc"]
+[sub_resource type="Resource" id="Resource_35mdi"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_7ot84")
+serialized_block = SubResource("Resource_8x341")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_2ykxc"]
+[sub_resource type="Resource" id="Resource_q2jh0"]
 script = ExtResource("3_dpt5n")
 block_class = &"StatementBlock"
-serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.890196, 0.0588235, 0.752941, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["block_format", "Play the sound {name: STRING} with Volume dB {db: FLOAT} and Pitch Scale {pitch: FLOAT}"], ["statement", "var sound = find_child({name})
-sound.volume_db = {db}
-sound.pitch_scale = {pitch}
-sound.play()"], ["param_input_strings", {
+serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.890196, 0.0588235, 0.752941, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["block_format", "Play the sound {name: STRING} with Volume dB {db: FLOAT} and Pitch Scale {pitch: FLOAT}"], ["statement", "VAR_DICT[{name}].volume_db = {db}
+VAR_DICT[{name}].pitch_scale = {pitch}
+VAR_DICT[{name}].play()"], ["defaults", {}], ["param_input_strings", {
 "db": "0.0",
 "name": "testsound",
 "pitch": "1.0"
 }]]
 
-[sub_resource type="Resource" id="Resource_s07iu"]
+[sub_resource type="Resource" id="Resource_r0t84"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_2ykxc")
+serialized_block = SubResource("Resource_q2jh0")
 path_child_pairs = []
 
-[sub_resource type="Resource" id="Resource_tu70f"]
+[sub_resource type="Resource" id="Resource_was6g"]
 script = ExtResource("3_dpt5n")
 block_class = &"ControlBlock"
-serialized_props = [["block_name", "control_block"], ["label", "Control Block"], ["color", Color(1, 0.678431, 0.462745, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["block_formats", ["if    {condition: BOOL}"]], ["statements", ["if {condition}:"]], ["param_input_strings_array", [{
-"condition": ""
+serialized_props = [["block_name", "control_block"], ["label", "Control Block"], ["color", Color(1, 0.678431, 0.462745, 1)], ["block_type", 2], ["position", Vector2(0, 0)], ["block_formats", ["if    {condition: BOOL}"]], ["statements", ["if {condition}:"]], ["defaults", {}], ["param_input_strings_array", [{
+"condition": false
 }]]]
 
-[sub_resource type="Resource" id="Resource_2hh05"]
+[sub_resource type="Resource" id="Resource_0blip"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_tu70f")
-path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_xyinc")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_s07iu")]]
+serialized_block = SubResource("Resource_was6g")
+path_child_pairs = [[NodePath("VBoxContainer/MarginContainer/Rows/Row0/RowHBoxContainer/RowHBox/ParameterInput0/SnapPoint"), SubResource("Resource_35mdi")], [NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer0/SnapPoint"), SubResource("Resource_r0t84")]]
 
-[sub_resource type="Resource" id="Resource_iskmc"]
+[sub_resource type="Resource" id="Resource_vlirs"]
 script = ExtResource("3_dpt5n")
 block_class = &"StatementBlock"
 serialized_props = [["block_name", "statement_block"], ["label", "StatementBlock"], ["color", Color(0.290196, 0.52549, 0.835294, 1)], ["block_type", 1], ["position", Vector2(0, 0)], ["block_format", "Move with player 2 buttons, speed {speed: INT}"], ["statement", "velocity = Input.get_vector(\"player_2_left\", \"player_2_right\", \"player_2_up\", \"player_2_down\")*{speed}
-move_and_slide()"], ["param_input_strings", {
+move_and_slide()"], ["defaults", {}], ["param_input_strings", {
 "speed": "600"
 }]]
 
-[sub_resource type="Resource" id="Resource_xmana"]
+[sub_resource type="Resource" id="Resource_kttbf"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_iskmc")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_2hh05")]]
+serialized_block = SubResource("Resource_vlirs")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_0blip")]]
 
-[sub_resource type="Resource" id="Resource_1yx4d"]
+[sub_resource type="Resource" id="Resource_u1q73"]
 script = ExtResource("3_dpt5n")
 block_class = &"EntryBlock"
-serialized_props = [["block_name", "physics_process_block"], ["label", "EntryBlock"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 1], ["position", Vector2(79, 270)], ["block_format", "On Physics Process"], ["statement", "func _physics_process(delta):"], ["param_input_strings", {}]]
+serialized_props = [["block_name", "physics_process_block"], ["label", "EntryBlock"], ["color", Color(0.980392, 0.34902, 0.337255, 1)], ["block_type", 1], ["position", Vector2(79, 270)], ["block_format", "On Physics Process"], ["statement", "func _physics_process(delta):"], ["defaults", {}], ["param_input_strings", {}], ["signal_name", ""]]
 
-[sub_resource type="Resource" id="Resource_eifs0"]
+[sub_resource type="Resource" id="Resource_l5pgq"]
 script = ExtResource("2_pqvcj")
-serialized_block = SubResource("Resource_1yx4d")
-path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_xmana")]]
+serialized_block = SubResource("Resource_u1q73")
+path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_kttbf")]]
 
-[sub_resource type="Resource" id="Resource_2hn5u"]
+[sub_resource type="Resource" id="Resource_cqtb7"]
 script = ExtResource("4_xt862")
-array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_xdg8y"), SubResource("Resource_eifs0")])
+array = Array[ExtResource("2_pqvcj")]([SubResource("Resource_7blgt"), SubResource("Resource_l5pgq")])
 
 [sub_resource type="Resource" id="Resource_l007i"]
 script = ExtResource("5_q37d3")
 script_inherits = "SimpleCharacter"
-block_trees = SubResource("Resource_2hn5u")
+block_trees = SubResource("Resource_cqtb7")
 generated_script = "extends SimpleCharacter
 
 var VAR_DICT := {}
@@ -154,20 +152,18 @@ func _ready():
 	var signal_manager = get_tree().root.get_node_or_null(\"SignalManager\")
 	if signal_manager:
 		signal_manager.broadcast_signal('Player', 'will_hi')
-	var sound = AudioStreamPlayer.new()
-	sound.name = 'testsound'
-	sound.set_stream(load('res://test_game/test_audio.ogg'))
-	add_child(sound)
-	sound.set_owner(self)
+	VAR_DICT['testsound'] = AudioStreamPlayer.new()
+	VAR_DICT['testsound'].name = 'testsound'
+	VAR_DICT['testsound'].set_stream(load('res://test_game/test_audio.ogg'))
+	add_child(VAR_DICT['testsound'])
 
 func _physics_process(delta):
 	velocity = Input.get_vector(\"player_2_left\", \"player_2_right\", \"player_2_up\", \"player_2_down\")*600
 	move_and_slide()
 	if Input.is_action_pressed(\"ui_right\"):
-		var sound = find_child('testsound')
-		sound.volume_db = 0.0
-		sound.pitch_scale = 1.0
-		sound.play()
+		VAR_DICT['testsound'].volume_db = 0.0
+		VAR_DICT['testsound'].pitch_scale = 1.0
+		VAR_DICT['testsound'].play()
 
 "
 


### PR DESCRIPTION
The new generated AudioStreamPlayer was held by a local variable, then added as a child of the node originally.

It is okay for only one AudioStreamPlayer in the node. However, some nodes may have mulitiple AudioStreamPlayers, then the local variable from the code blocks will be conflicted, due to the same variable name.

Therefore, store the AudioStreamPlayer into the node's global VAR_DICT with a key passed from the parameter "name" directly. This also avoids searching in the node tree.

https://phabricator.endlessm.com/T35501