### PR TITLE
Add a "Send signal to node" block

### DIFF
--- a/addons/block_code/block_code_node/utilities/signal_manager.gd
+++ b/addons/block_code/block_code_node/utilities/signal_manager.gd
@@ -7,3 +7,13 @@ func broadcast_signal(group: String, signal_name: String):
 		await get_tree().root.ready
 
 	get_tree().call_group(group, "signal_" + signal_name)
+
+
+func send_signal_to_node(path: NodePath, signal_name: String):
+	# Make sure all nodes have been readied and scripts loaded before running signals
+	if not get_tree().root.is_node_ready():
+		await get_tree().root.ready
+
+	var node = get_node(path)
+	if node:
+		node.call("signal_" + signal_name)

--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -198,7 +198,13 @@ static func get_general_blocks() -> Array[Block]:
 
 	b = BLOCKS["statement_block"].instantiate()
 	b.block_format = "Send signal {signal: STRING} to group {group: STRING}"
-	b.statement = 'var signal_manager = get_tree().root.get_node_or_null("SignalManager")\n' + "if signal_manager:\n" + "\tsignal_manager.broadcast_signal({group}, {signal})"
+	b.statement = 'if get_tree().root.has_node("SignalManager"):\n' + '\tget_tree().root.get_node_or_null("SignalManager").broadcast_signal({group}, {signal})'
+	b.category = "Signal"
+	block_list.append(b)
+
+	b = BLOCKS["statement_block"].instantiate()
+	b.block_format = "Send signal {signal: STRING} to node {node: NODE_PATH}"
+	b.statement = 'if get_tree().root.has_node("SignalManager"):\n' + '\tget_tree().root.get_node_or_null("SignalManager").send_signal_to_node({node}, {signal})'
 	b.category = "Signal"
 	block_list.append(b)
 


### PR DESCRIPTION
In #60, I wasn't a fan of us needing to reset _all_ of the ball nodes when a player scores, so I'm proposing a "send signal to node" block. This requires a little bit of tweaking so we aren't defining `var signal_manager` in either of the send signal blocks, which makes it possible to include multiple of them in the same context.