### PR TITLE
github: Update Asset Library ID

### DIFF
--- a/.github/workflows/godot-asset-library.yaml
+++ b/.github/workflows/godot-asset-library.yaml
@@ -18,4 +18,4 @@ jobs:
         with:
           username: ${{ secrets.GODOT_ASSET_LIBRARY_USERNAME }}
           password: ${{ secrets.GODOT_ASSET_LIBRARY_PASSWORD }}
-          assetId: 12617
+          assetId: 3095


### PR DESCRIPTION
Now that the plugin has been accepted, it appears the ID is 3095 per https://godotengine.org/asset-library/asset/3095. I guess the previous ID was just for the submission.

https://phabricator.endlessm.com/T35503