### PR TITLE
When generating a script, merge duplicate entry blocks

### DIFF
--- a/addons/block_code/ui/block_canvas/node_block_canvas/node_block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/node_block_canvas/node_block_canvas.gd
@@ -7,16 +7,17 @@ func generate_script_from_current_window(script_inherits: String = ""):
 	# TODO: implement multiple windows
 	var current_window := _window
 
-	var blocks := current_window.get_children()
+	var entry_blocks_by_entry_statement: Dictionary = {}
 
-	var entry_blocks: Array[EntryBlock] = []
-
-	for c in blocks:
-		if !(c is Block):
+	for block in current_window.get_children():
+		if !(block is Block):
 			continue
 
-		if c is EntryBlock:
-			entry_blocks.append(c)
+		if block is EntryBlock:
+			var entry_statement = block.get_entry_statement()
+			if not entry_blocks_by_entry_statement.has(entry_statement):
+				entry_blocks_by_entry_statement[entry_statement] = []
+			entry_blocks_by_entry_statement[entry_statement].append(block)
 
 	var script: String = ""
 
@@ -26,9 +27,21 @@ func generate_script_from_current_window(script_inherits: String = ""):
 
 	var init_func = InstructionTree.TreeNode.new("func _init():")
 
-	for entry_block in entry_blocks:
-		script += entry_block.get_entry_statement() + "\n"
+	for entry_statement in entry_blocks_by_entry_statement:
+		var entry_blocks: Array[EntryBlock]
+		entry_blocks.assign(entry_blocks_by_entry_statement[entry_statement])
+		script += _generate_script_from_entry_blocks(entry_statement, entry_blocks, init_func)
 
+	if init_func.children:
+		script += InstructionTree.new().generate_text(init_func)
+
+	return script
+
+
+func _generate_script_from_entry_blocks(entry_statement: String, entry_blocks: Array[EntryBlock], init_func: InstructionTree.TreeNode) -> String:
+	var script = entry_statement + "\n"
+
+	for entry_block in entry_blocks:
 		var next_block := entry_block.bottom_snap.get_snapped_block()
 
 		if next_block == null:
@@ -43,8 +56,5 @@ func generate_script_from_current_window(script_inherits: String = ""):
 
 		if entry_block.signal_name:
 			init_func.add_child(InstructionTree.TreeNode.new("{0}.connect(_on_{0})".format([entry_block.signal_name])))
-
-	if init_func.children:
-		script += InstructionTree.new().generate_text(init_func)
 
 	return script


### PR DESCRIPTION
If the user places multiple of the same entry block, all of the entry blocks should run. To support this, we will group entry blocks by entry statement.