### PR TITLE
Add camera to fit default project size

### DIFF
--- a/addons/block_code/examples/pong_game/pong_game.tscn
+++ b/addons/block_code/examples/pong_game/pong_game.tscn
@@ -1063,7 +1063,12 @@ script = ExtResource("3_6jaq8")
 block_script = SubResource("Resource_6drva")
 
 [node name="HUD" parent="." instance=ExtResource("8_yg457")]
+follow_viewport_enabled = true
 
 [node name="BlockCode" type="Node" parent="."]
 script = ExtResource("3_6jaq8")
 block_script = SubResource("Resource_f070g")
+
+[node name="Camera2D" type="Camera2D" parent="."]
+position = Vector2(960, 540)
+zoom = Vector2(0.6, 0.6)


### PR DESCRIPTION
The Godot project size defaults to 1152x648 which is 60% of the viewport in Pong. So adding a camera with 0.6 zoom makes the game fit in the default viewport. And makes it look odd in other sizes.

Also now the HUD layer follows the viewport size.

https://phabricator.endlessm.com/T35515