### PR TITLE
Add scope to blocks

### DIFF
--- a/addons/block_code/drag_manager/drag_manager.gd
+++ b/addons/block_code/drag_manager/drag_manager.gd
@@ -206,6 +206,9 @@ func drag_block(block: Block, copied_from: Block = null):
 	drag = Drag.new(block, offset, _block_canvas)
 	add_child(drag)
 
+	if block.scope != "":
+		_block_canvas.set_scope(block.scope)
+
 
 func copy_block(block: Block) -> Block:
 	return block.duplicate(DUPLICATE_USE_INSTANTIATION)  # use instantiation
@@ -226,6 +229,8 @@ func drag_ended():
 
 	if block:
 		connect_block_canvas_signals(block)
+
+	_block_canvas.release_scope()
 
 	drag.queue_free()
 	drag = null

--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -121,3 +121,20 @@ func find_snaps(node: Node) -> Array:
 			snaps.append_array(find_snaps(c))
 
 	return snaps
+
+
+func set_scope(scope: String):
+	for block in _window.get_children():
+		if block is EntryBlock:
+			var entry_block = block as EntryBlock
+
+			if scope != entry_block.get_entry_statement():
+				entry_block.modulate = Color(0.5, 0.5, 0.5, 1)
+
+
+func release_scope():
+	for block in _window.get_children():
+		if block is EntryBlock:
+			var entry_block = block as EntryBlock
+
+			entry_block.modulate = Color.WHITE

--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -125,16 +125,20 @@ func find_snaps(node: Node) -> Array:
 
 func set_scope(scope: String):
 	for block in _window.get_children():
-		if block is EntryBlock:
-			var entry_block = block as EntryBlock
+		var valid := false
 
-			if scope != entry_block.get_entry_statement():
-				entry_block.modulate = Color(0.5, 0.5, 0.5, 1)
+		if block is EntryBlock:
+			if scope == block.get_entry_statement():
+				valid = true
+		else:
+			var tree_scope := DragManager.get_tree_scope(block)
+			if tree_scope == "" or scope == tree_scope:
+				valid = true
+
+		if not valid:
+			block.modulate = Color(0.5, 0.5, 0.5, 1)
 
 
 func release_scope():
 	for block in _window.get_children():
-		if block is EntryBlock:
-			var entry_block = block as EntryBlock
-
-			entry_block.modulate = Color.WHITE
+		block.modulate = Color.WHITE

--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -23,6 +23,9 @@ signal modified
 ## The next block in the line of execution (can be null if end)
 @export var bottom_snap_path: NodePath
 
+## The scope of the block (statement of matching entry block)
+@export var scope: String = ""
+
 var bottom_snap: SnapPoint
 
 
@@ -62,7 +65,7 @@ func get_instruction_node() -> InstructionTree.TreeNode:
 
 # Override this method to add more serialized properties
 func get_serialized_props() -> Array:
-	return serialize_props(["block_name", "label", "color", "block_type", "position"])
+	return serialize_props(["block_name", "label", "color", "block_type", "position", "scope"])
 
 
 func serialize_props(prop_names: Array) -> Array:


### PR DESCRIPTION
Made it so that parameter blocks copy-dragged from an `EntryBlock` can only be placed below entry blocks with the same method signature.

Also darken the block trees that cannot be snapped to by the current dragged block.

https://phabricator.endlessm.com/T35521