### PR TITLE
github: Drop the publish job's action type check

### DIFF
--- a/.github/workflows/godot-asset-library.yaml
+++ b/.github/workflows/godot-asset-library.yaml
@@ -7,7 +7,6 @@ name: Push to Godot Asset Library
 
 jobs:
   publish:
-    if: github.event.action == 'released'
     runs-on: ubuntu-latest
     name: Push new release
     steps:


### PR DESCRIPTION
Current publish job is only triggered by published release. But, it is guarded by "released" action. The mismatched condition blocks the jobs. Drop the publish job's action type check to avoid this issue.