### PR TITLE
Populate more fields of plugin.cfg

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,5 @@
 /addons               !export-ignore
 /addons/block_code    !export-ignore
 /addons/block_code/** !export-ignore
+
+/addons/block_code/plugin.cfg export-subst

--- a/addons/block_code/plugin.cfg
+++ b/addons/block_code/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
 name="BlockCode"
-description="Plugin that enables block coding that can be translated to GDScript."
-author=""
+description="Create games using a high-level, block-based visual programming language."
+author="Endless"
 version=""
 script="block_code_plugin.gd"

--- a/addons/block_code/plugin.cfg
+++ b/addons/block_code/plugin.cfg
@@ -3,5 +3,5 @@
 name="BlockCode"
 description="Create games using a high-level, block-based visual programming language."
 author="Endless"
-version=""
+version="$Format:%(describe)$"
 script="block_code_plugin.gd"


### PR DESCRIPTION
These are shown in the plugins section of the project settings.

The author and description fields can be populated statically, but the version number cannot unless we manually update it for each release. Instead, lean on a feature of `git archive` where magic placeholders in specified files can be substituted for strings based on the current commit, crucially including the output of `git describe` which will return a tag name if the current commit is an annotated tag.

v0.2.0 is annotated while v0.1.0 was not.

https://phabricator.endlessm.com/T35503