### PR TITLE
Fix Simple node setup not happening

### DIFF
--- a/addons/block_code/block_code_node/block_code.gd
+++ b/addons/block_code/block_code_node/block_code.gd
@@ -60,6 +60,10 @@ func _update_parent_script():
 	for property_name in persist_properties:
 		parent.set(property_name, persist_properties.get(property_name))
 
+	# Run simple setup after node is ready
+	if parent.has_method("simple_setup"):
+		parent.call_deferred("simple_setup")
+
 
 func _get_configuration_warnings():
 	var warnings = []

--- a/addons/block_code/simple_nodes/simple_character/simple_character.gd
+++ b/addons/block_code/simple_nodes/simple_character/simple_character.gd
@@ -19,6 +19,10 @@ func _set_texture(new_texture):
 
 
 func _ready():
+	simple_setup()
+
+
+func simple_setup():
 	_set_texture(texture)
 
 


### PR DESCRIPTION
Any Simple node like `SimpleCharacter` will have its `_ready` overwritten by the block script if a ready block exists. This PR enables setup for the Simple node to still happen regardless. (e.g. Pong paddle texture initialization)

This was the best way I could find to do this. Calling `super()` in the child `_ready` when `_ready` is not overridden in the parent causes an error (even though it's a virtual method...). I don't know of any way to check if the method is overridden in the parent to call it or not.