### PR TITLE
ci: Use my fork of godot-asset-lib-action

### DIFF
--- a/.github/workflows/godot-asset-library.yaml
+++ b/.github/workflows/godot-asset-library.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Push to Godot Asset Library
-        uses: deep-entertainment/godot-asset-lib-action@v0.4.0
+        uses: wjt/godot-asset-lib-action@fd3395aa70bba333c0d3cc33c78dc03c18d149ae
         with:
           username: ${{ secrets.GODOT_ASSET_LIBRARY_USERNAME }}
           password: ${{ secrets.GODOT_ASSET_LIBRARY_PASSWORD }}


### PR DESCRIPTION
The referenced commit is the merge of these two PRs:

https://github.com/deep-entertainment/godot-asset-lib-action/pull/2
https://github.com/deep-entertainment/godot-asset-lib-action/pull/3

https://phabricator.endlessm.com/T35503
