### PR TITLE
plugin.cfg: Use lightweight tags to determine version

### DIFF
--- a/addons/block_code/plugin.cfg
+++ b/addons/block_code/plugin.cfg
@@ -3,5 +3,5 @@
 name="BlockCode"
 description="Create games using a high-level, block-based visual programming language."
 author="Endless"
-version="$Format:%(describe)$"
+version="$Format:%(describe:tags)$"
 script="block_code_plugin.gd"


### PR DESCRIPTION
By default, `git describe` (which is what backs this
`$Format:%(describe)$` placeholder) only uses annotated tags to
construct a version number.

However I have just discovered that if you use the GitHub web interface
to create a tag as part of making a release, the resulting tag is
lightweight, not annotated. As a result the 0.4.0 release describes its
version as `v0.3.1-27-ga9a2ee9`.

Update the placeholder to (the equivalent of) `git describe --tags`,
which considers lightweight tags as well as annotated tags.
