### PR TITLE
ci: Check that releases use annotated tags

### DIFF
--- a/.github/workflows/godot-asset-library.yaml
+++ b/.github/workflows/godot-asset-library.yaml
@@ -12,6 +12,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - name: Check tag is annotated
+        run: |
+          [[ $(git cat-file -t ${{ github.event.release.tag_name }}) == "tag" ]]
       - name: Push to Godot Asset Library
         uses: wjt/godot-asset-lib-action@9cce3792b504bec69eb06b852b008d095e372f56
         with:


### PR DESCRIPTION
If you use the GitHub web interface to make a tag together with a
release, the resulting tag is lightweight, not annotated. Release tags
should be annotated.

With this change we could revert
b262af0b88dcf435a9527894b352e04971d37863. We might also want another
workflow that checks that any new tag matching `v*` is annotated.
