### PR TITLE
main_panel: Correct tooltip for block picker toggle button

### DIFF
--- a/addons/block_code/ui/main_panel.tscn
+++ b/addons/block_code/ui/main_panel.tscn
@@ -73,7 +73,7 @@ layout_mode = 2
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 8
-tooltip_text = "Collapse the picker toolbar. Shortcut (Ctrl-Space)"
+tooltip_text = "Toggle Block Picker (Ctrl+BackSlash)"
 flat = true
 
 [node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer/HBoxContainer/ScriptVBox/MarginContainer/PickerSplit/MarginContainer/VBoxContainer/BottomBar"]


### PR DESCRIPTION
The tooltip previously claimed that the shortcut was Ctrl + Space, but in fact it is Ctrl + Backslash.

Fix this error; and adjust the tooltip style to match the tooltip on the equivalent button in the script editor view. I personally don't like the camel-casing of BackSlash but that's what Godot calls that key.

https://phabricator.endlessm.com/T35540