### PR TITLE
background: Avoid infinite draw cycle

### DIFF
--- a/addons/block_code/ui/blocks/utilities/background/background.gd
+++ b/addons/block_code/ui/blocks/utilities/background/background.gd
@@ -3,11 +3,10 @@ extends Control
 
 const Constants = preload("res://addons/block_code/ui/constants.gd")
 
+var outline_color: Color
+
 @export var color: Color:
 	set = _set_color
-
-@export var outline_color: Color:
-	set = _set_outline_color
 
 @export var show_top: bool = true:
 	set = _set_show_top
@@ -23,11 +22,7 @@ const Constants = preload("res://addons/block_code/ui/constants.gd")
 
 func _set_color(new_color):
 	color = new_color
-	queue_redraw()
-
-
-func _set_outline_color(new_outline_color):
-	outline_color = new_outline_color
+	outline_color = color.darkened(0.2)
 	queue_redraw()
 
 
@@ -47,8 +42,6 @@ func _set_shift_bottom(new_shift_bottom):
 
 
 func _draw():
-	outline_color = color.darkened(0.2)
-
 	var fill_polygon: PackedVector2Array
 	fill_polygon.append(Vector2(0.0, 0.0))
 	if show_top:


### PR DESCRIPTION
Setting outline_color queues a redraw, so setting it in the draw handler implies that it will queue infinite redraws. In Godot 4.2 this doesn't happen, but in Godot 4.3 it does and causes the editor to lock up until it finally crashes.

I don't know if it's a bug in one version or the other, but either way we don't need to do that. If outline_color is already set based on the color, then set it at the time color is set and stop exporting it since any user provided value would be ignored.

https://phabricator.endlessm.com/T35494