### PR TITLE
category_factory: Fix static Callable use in Godot 4.2.1

### DIFF
--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -150,7 +150,10 @@ static func get_categories(blocks: Array[Block], extra_categories: Array[BlockCa
 	# convert an array type besides Array.assign().
 	var cats: Array[BlockCategory] = []
 	cats.assign(cat_map.values())
-	cats.sort_custom(_category_cmp)
+	# Accessing a static Callable from a static function fails in 4.2.1.
+	# Use the fully qualified name.
+	# https://github.com/godotengine/godot/issues/86032
+	cats.sort_custom(CategoryFactory._category_cmp)
 	return cats
 
 


### PR DESCRIPTION
In Godot 4.2.1, a static function used as a Callable from a static function fails to be resolved. This causes the following error in our case:

```
res://addons/block_code/ui/picker/categories/category_factory.gd:109 -
Invalid get index '_category_cmp' (on base: 'Nil')
```

See https://github.com/godotengine/godot/issues/86032 for details. This can be worked around by using the fully qualified class method name.

Fixes: #94