### PR TITLE
Add blockcode warnings

### DIFF
--- a/addons/block_code/block_code_node/block_code.gd
+++ b/addons/block_code/block_code_node/block_code.gd
@@ -69,6 +69,8 @@ func _get_configuration_warnings():
 	var warnings = []
 	if get_parent() is BlockCode:
 		warnings.append("The parent must not be a BlockCode.")
+	if get_parent().find_children("*", "BlockCode", false).size() > 1:
+		warnings.append("The parent should only contain one BlockCode.")
 	if block_script and _get_custom_or_native_class(get_parent()) != block_script.script_inherits:
 		var warning = "The parent is not a %s. Create a new BlockCode node and reattach." % block_script.script_inherits
 		warnings.append(warning)

--- a/addons/block_code/block_code_node/block_code.gd
+++ b/addons/block_code/block_code_node/block_code.gd
@@ -67,6 +67,8 @@ func _update_parent_script():
 
 func _get_configuration_warnings():
 	var warnings = []
+	if self.owner == null:
+		warnings.append("A BlockCode must not be a root node.")
 	if get_parent() is BlockCode:
 		warnings.append("The parent must not be a BlockCode.")
 	if get_parent().find_children("*", "BlockCode", false).size() > 1:

--- a/addons/block_code/block_code_node/block_code.gd
+++ b/addons/block_code/block_code_node/block_code.gd
@@ -67,6 +67,8 @@ func _update_parent_script():
 
 func _get_configuration_warnings():
 	var warnings = []
+	if get_parent() is BlockCode:
+		warnings.append("The parent must not be a BlockCode.")
 	if block_script and _get_custom_or_native_class(get_parent()) != block_script.script_inherits:
 		var warning = "The parent is not a %s. Create a new BlockCode node and reattach." % block_script.script_inherits
 		warnings.append(warning)


### PR DESCRIPTION
This adds some new warnings to `BlockCode` to deal with common problems users may encounter:

![Screenshot from 2024-07-05 13-06-08](https://github.com/endlessm/godot-block-coding/assets/132063/54cdf63e-a4a3-489f-b678-38ea7f100cf5)

Note that the "parent should only contain on BlockCode" warning also occurs when the parent is a separate (instantiated) scene. I simulated that in the screenshot by adding a `BlockCode` node to space.tscn, so in pong_game.tscn, where I added another `BlockCode` under `Space`, we get a warning.