### PR TITLE
Make SimpleCharacter more flexible

### DIFF
--- a/addons/block_code/simple_nodes/simple_character/simple_character.gd
+++ b/addons/block_code/simple_nodes/simple_character/simple_character.gd
@@ -5,6 +5,9 @@ extends CharacterBody2D
 @export var texture: Texture2D:
 	set = _set_texture
 
+@export var speed: Vector2 = Vector2(300, 300):
+	set = _set_speed
+
 const PLAYER_KEYS = {
 	"player_1":
 	{
@@ -22,6 +25,11 @@ const PLAYER_KEYS = {
 	}
 }
 
+# Get the gravity from the project settings to be synced with RigidBody nodes.
+var gravity = ProjectSettings.get_setting("physics/2d/default_gravity")
+
+var _jumping = false
+
 
 func _set_texture(new_texture):
 	texture = new_texture
@@ -35,25 +43,58 @@ func _set_texture(new_texture):
 	$CollisionShape2D.shape = shape
 
 
+func _set_speed(new_speed):
+	speed = new_speed
+
+
+## Nodes in the "affected_by_gravity" group will receive gravity changes:
+func on_gravity_changed(new_gravity):
+	gravity = new_gravity
+
+
 func _ready():
+	add_to_group("affected_by_gravity")
 	simple_setup()
 
 
 func simple_setup():
 	_set_texture(texture)
+	_set_speed(speed)
 
 
 func get_custom_class():
 	return "SimpleCharacter"
 
 
-func move_with_player_buttons(player: String, speed: Vector2):
-	var dir = Vector2()
-	dir.x += float(Input.is_physical_key_pressed(PLAYER_KEYS[player]["right"]))
-	dir.x -= float(Input.is_physical_key_pressed(PLAYER_KEYS[player]["left"]))
-	dir.y += float(Input.is_physical_key_pressed(PLAYER_KEYS[player]["down"]))
-	dir.y -= float(Input.is_physical_key_pressed(PLAYER_KEYS[player]["up"]))
-	velocity = dir.normalized() * speed
+func _player_input_to_direction(player: String):
+	var direction = Vector2()
+	direction.x += float(Input.is_physical_key_pressed(PLAYER_KEYS[player]["right"]))
+	direction.x -= float(Input.is_physical_key_pressed(PLAYER_KEYS[player]["left"]))
+	direction.y += float(Input.is_physical_key_pressed(PLAYER_KEYS[player]["down"]))
+	direction.y -= float(Input.is_physical_key_pressed(PLAYER_KEYS[player]["up"]))
+	return direction
+
+
+func move_with_player_buttons(player: String, kind: String, delta: float):
+	var direction = _player_input_to_direction(player)
+
+	if kind == "top-down":
+		velocity = direction * speed
+
+	elif kind == "platformer":
+		velocity.x = direction.x * speed.x
+		if not is_on_floor():
+			velocity.y += gravity * delta
+		else:
+			if not _jumping and Input.is_physical_key_pressed(PLAYER_KEYS[player]["up"]):
+				_jumping = true
+				velocity.y -= speed.y
+			else:
+				_jumping = false
+
+	elif kind == "spaceship":
+		rotation_degrees += direction.x * speed.x / 100.0
+		velocity = Vector2.DOWN.rotated(rotation) * speed.y * direction.y
 	move_and_slide()
 
 
@@ -64,13 +105,27 @@ static func get_custom_blocks() -> Array[Block]:
 	# Movement
 	b = CategoryFactory.BLOCKS["statement_block"].instantiate()
 	b.block_type = Types.BlockType.EXECUTE
-	b.block_format = "Move with {player: OPTION} buttons, speed {speed: VECTOR2}"
-	b.statement = 'move_with_player_buttons("{player}", {speed})'
+	b.block_format = "Move with {player: OPTION} buttons as {kind: OPTION}"
+	# TODO: delta here is assumed to be the parameter name of
+	# the _process or _physics_process method:
+	b.statement = 'move_with_player_buttons("{player}", "{kind}", delta)'
 	b.defaults = {
 		"player": OptionData.new(["player_1", "player_2"]),
-		"speed": "300,300",
+		"kind": OptionData.new(["top-down", "platformer", "spaceship"]),
 	}
 	b.category = "Input"
 	block_list.append(b)
+
+	var property_blocks = (
+		CategoryFactory
+		. property_to_blocklist(
+			{
+				"name": "speed",
+				"type": TYPE_VECTOR2,
+				"category": "Physics | Velocity",
+			}
+		)
+	)
+	block_list.append_array(property_blocks)
 
 	return block_list

--- a/project.godot
+++ b/project.godot
@@ -19,10 +19,6 @@ config/icon="res://icon.svg"
 
 enabled=PackedStringArray("res://addons/block_code/plugin.cfg", "res://addons/gut/plugin.cfg", "res://addons/plugin_refresher/plugin.cfg")
 
-[physics]
-
-2d/default_gravity=0.0
-
 [rendering]
 
 renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
To allow different movement kinds for different game possibilities. The previous is now the default and named "as top-down". In addition, now "as platformer" and "as spaceship" are available.

The speed is now exposed as a property to prevent the block getting too long with 3 parameters. The speed vector is used differently in each situation:
- for platformer, Y is the jump speed
- for spaceship, X is the rotation speed

For platformer, the gravity is read from project settings, but also there is a method to update it.

Remove the gravity custom setting from the project setting, that was added back at some point by mistake.

https://phabricator.endlessm.com/T35549