### PR TITLE
Set MOUSE_FILTER_IGNORE for blocks where necessary

### DIFF
--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -31,6 +31,7 @@ var bottom_snap: SnapPoint
 
 func _ready():
 	bottom_snap = get_node_or_null(bottom_snap_path)
+	mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 
 static func get_block_class():

--- a/addons/block_code/ui/blocks/control_block/control_block.gd
+++ b/addons/block_code/ui/blocks/control_block/control_block.gd
@@ -141,7 +141,10 @@ func format():
 
 		var snap_container := MarginContainer.new()
 		snap_container.name = "SnapContainer%d" % i
+		snap_container.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		snap_container.custom_minimum_size.x = 30
 		snap_container.custom_minimum_size.y = 30
+		snap_container.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
 		snap_container.add_theme_constant_override("margin_left", Constants.CONTROL_MARGIN)
 
 		var snap_point: SnapPoint = preload("res://addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn").instantiate()

--- a/addons/block_code/ui/blocks/control_block/control_block.tscn
+++ b/addons/block_code/ui/blocks/control_block/control_block.tscn
@@ -5,6 +5,7 @@
 
 [node name="ControlBlock" type="MarginContainer"]
 size_flags_horizontal = 0
+mouse_filter = 2
 script = ExtResource("1_2hbir")
 block_name = "control_block"
 label = "Control Block"
@@ -13,13 +14,16 @@ bottom_snap_path = NodePath("VBoxContainer/SnapPoint")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
+mouse_filter = 2
 theme_override_constants/separation = 0
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer"]
 layout_mode = 2
+mouse_filter = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/MarginContainer"]
 layout_mode = 2
+mouse_filter = 2
 theme_override_constants/margin_top = 30
 theme_override_constants/margin_bottom = 30
 
@@ -34,8 +38,8 @@ color = Color(0.59979, 0.536348, 0.876215, 1)
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 0
+mouse_filter = 2
 theme_override_constants/separation = 0
 
 [node name="SnapPoint" parent="VBoxContainer" instance=ExtResource("3_nhryi")]
 layout_mode = 2
-block_path = NodePath("../..")

--- a/addons/block_code/ui/blocks/statement_block/statement_block.tscn
+++ b/addons/block_code/ui/blocks/statement_block/statement_block.tscn
@@ -7,20 +7,22 @@
 
 [node name="StatementBlock" type="MarginContainer"]
 size_flags_horizontal = 0
+mouse_filter = 2
 script = ExtResource("1_6wvlf")
-defaults = null
 block_name = "statement_block"
 label = "StatementBlock"
 bottom_snap_path = NodePath("VBoxContainer/SnapPoint")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
+mouse_filter = 2
 theme_override_constants/separation = 0
 
 [node name="TopMarginContainer" type="MarginContainer" parent="VBoxContainer"]
 custom_minimum_size = Vector2(0, 30)
 layout_mode = 2
 size_flags_horizontal = 0
+mouse_filter = 2
 theme_override_constants/margin_left = 0
 theme_override_constants/margin_top = 0
 theme_override_constants/margin_right = 0
@@ -32,7 +34,6 @@ layout_mode = 2
 mouse_filter = 1
 script = ExtResource("2_lctqt")
 color = Color(1, 1, 1, 1)
-outline_color = Color(0.8, 0.8, 0.8, 1)
 
 [node name="DragDropArea" parent="VBoxContainer/TopMarginContainer" instance=ExtResource("2_owgdx")]
 layout_mode = 2
@@ -54,6 +55,5 @@ theme_override_constants/separation = 0
 
 [node name="SnapPoint" parent="VBoxContainer" instance=ExtResource("3_5vaov")]
 layout_mode = 2
-block_path = NodePath("../..")
 
 [connection signal="mouse_down" from="VBoxContainer/TopMarginContainer/DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]

--- a/addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn
+++ b/addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn
@@ -10,6 +10,7 @@ offset_right = -1152.0
 offset_bottom = -648.0
 grow_horizontal = 2
 grow_vertical = 2
+mouse_filter = 2
 script = ExtResource("1_kseym")
 
 [connection signal="child_entered_tree" from="." to="." method="_on_child_entered_tree"]


### PR DESCRIPTION
Certain components inside our Block scenes were consuming input events, making it difficult to interact with other blocks positioned around them.