### PR TITLE
Add _to_string for Block

### DIFF
--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -69,6 +69,10 @@ func get_serialized_props() -> Array:
 	return serialize_props(["block_name", "label", "color", "block_type", "position", "scope"])
 
 
+func _to_string():
+	return "<{block_class}:{block_name}#{rid}>".format({"block_name": block_name, "block_class": get_block_class(), "rid": get_instance_id()})
+
+
 func serialize_props(prop_names: Array) -> Array:
 	var pairs := []
 	for p in prop_names:


### PR DESCRIPTION
The to_string implementation for Block follows the same pattern as the default for Godot objects, but it uses get_block_class and includes the block_name property for each block. This will make it easier to differentiate between different blocks while debugging the block code editor.

-----

This is inspired by #132, where we add block_name for all of the blocks.