### PR TITLE
Add rich-text tooltips for blocks

### DIFF
--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -74,3 +74,9 @@ func serialize_props(prop_names: Array) -> Array:
 	for p in prop_names:
 		pairs.append([p, self.get(p)])
 	return pairs
+
+
+func _make_custom_tooltip(for_text) -> Control:
+	var tooltip = preload("res://addons/block_code/ui/tooltip/tooltip.tscn").instantiate()
+	tooltip.text = for_text
+	return tooltip

--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -206,12 +206,21 @@ static func get_general_blocks() -> Array[Block]:
 	b.block_formats = ["repeat {number: INT}"]
 	b.statements = ["for i in {number}:"]
 	b.category = "Loops"
+	b.tooltip_text = "Run the connected blocks [i]number[/i] times"
 	block_list.append(b)
 
 	b = BLOCKS["control_block"].instantiate()
 	b.block_formats = ["while {condition: BOOL}"]
 	b.statements = ["while {condition}:"]
 	b.category = "Loops"
+	b.tooltip_text = (
+		"""
+	Run the connected blocks as long as [i]condition[/i] is true.
+
+	Hint: snap a [b]Comparison[/b] block into the condition.
+	"""
+		. dedent()
+	)
 	block_list.append(b)
 
 	b = BLOCKS["statement_block"].instantiate()

--- a/addons/block_code/ui/tooltip/tooltip.gd
+++ b/addons/block_code/ui/tooltip/tooltip.gd
@@ -1,0 +1,24 @@
+@tool
+class_name Tooltip
+extends RichTextLabel
+## Rich-text control for block tooltips that matches the built-in inspector's tooltips' font styles
+
+
+func override_font(font_name: StringName, editor_font_name: StringName) -> Font:
+	var font = get_theme_font(editor_font_name, &"EditorFonts")
+	add_theme_font_override(font_name, font)
+	return font
+
+
+func _ready():
+	# Set fonts to match documentation tooltips in inspector
+	override_font(&"normal_font", &"doc")
+	override_font(&"mono_font", &"doc_source")
+	override_font(&"bold_font", &"doc_bold")
+	var italics = override_font(&"italics_font", &"doc_italic")
+
+	# No doc_ style for bold italic; fake it by emboldening the italic style
+	var bold_italics = FontVariation.new()
+	bold_italics.set_base_font(italics)
+	bold_italics.set_variation_embolden(1.2)
+	add_theme_font_override(&"bold_italics_font", bold_italics)

--- a/addons/block_code/ui/tooltip/tooltip.tscn
+++ b/addons/block_code/ui/tooltip/tooltip.tscn
@@ -1,0 +1,14 @@
+[gd_scene load_steps=2 format=3 uid="uid://bmxco03vqyq2t"]
+
+[ext_resource type="Script" path="res://addons/block_code/ui/tooltip/tooltip.gd" id="1_4ko6a"]
+
+[node name="Tooltip" type="RichTextLabel"]
+custom_minimum_size = Vector2(360, 48)
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+bbcode_enabled = true
+fit_content = true
+script = ExtResource("1_4ko6a")


### PR DESCRIPTION
This overrides the tooltip of all blocks to be a custom control (a thin wrapper around RichTextLabel) and adds a couple of new tooltips that take advantage of this:

![image](https://github.com/user-attachments/assets/d171ca9b-1647-48c7-a961-e30b347fdfb6)

I don't want to spend too much time on the tooltips themselves because we intend to review the wording of the blocks themselves & terminology used in conjuction with the learning team – and potentially changing the level of abstraction of some of the blocks. Similarly I could imagine making the tooltips fancier by, for example, listing the parameters, adding a note about what kind of block it is, etc. But again I think this would be better done in conjuction with the learning team. So here I'm focusing on just having the capability to use rich text in tooltips.

https://phabricator.endlessm.com/T35540