### PR TITLE
ci: Set Python version for setup-python

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -13,6 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
     - name: set PY
       run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
     - uses: actions/cache@v4


### PR DESCRIPTION
This fixes the following warning that was previously seen on every run of the checks workflow:

> Warning: Neither 'python-version' nor 'python-version-file' inputs were supplied. Attempting to find '.python-version' file.
> Warning: .python-version doesn't exist.
> Warning: The `python-version` input is not set.  The version of Python currently in `PATH` will be used.

Python 3.11 happens to be what is in Endless OS 6.