### PR TITLE
Serialization: Reuse SerializedBlock resources

### DIFF
--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -100,8 +100,9 @@ func bsd_selected(bsd: BlockScriptData):
 
 	var edited_node = EditorInterface.get_inspector().get_edited_object() as Node
 
-	_window.position = Vector2(0, 0)
-	zoom = 1
+	if bsd != _current_bsd:
+		_window.position = Vector2(0, 0)
+		zoom = 1
 
 	_window.visible = false
 	_zoom_label.visible = false

--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -40,8 +40,6 @@ var zoom: float:
 	get:
 		return _window.scale.x
 
-var _undo_redo: EditorUndoRedoManager
-
 signal reconnect_block(block: Block)
 signal add_block_code
 signal open_scene
@@ -174,27 +172,26 @@ func load_tree(parent: Node, node: SerializedBlockTreeNode):
 
 
 func rebuild_block_trees(undo_redo):
-	_undo_redo = undo_redo
 	var block_trees_array = []
 	for c in _window.get_children():
-		block_trees_array.append(build_tree(c))
+		block_trees_array.append(build_tree(c, undo_redo))
 	undo_redo.add_undo_property(_current_bsd.block_trees, "array", _current_bsd.block_trees.array)
 	undo_redo.add_do_property(_current_bsd.block_trees, "array", block_trees_array)
 
 
-func build_tree(block: Block) -> SerializedBlockTreeNode:
+func build_tree(block: Block, undo_redo: EditorUndoRedoManager) -> SerializedBlockTreeNode:
 	var path_child_pairs = []
-	block.update_resources(_undo_redo)
+	block.update_resources(undo_redo)
 
 	for snap in find_snaps(block):
 		var snapped_block = snap.get_snapped_block()
 		if snapped_block == null:
 			continue
-		path_child_pairs.append([block.get_path_to(snap), build_tree(snapped_block)])
+		path_child_pairs.append([block.get_path_to(snap), build_tree(snapped_block, undo_redo)])
 
 	if block.resource.path_child_pairs != path_child_pairs:
-		_undo_redo.add_undo_property(block.resource, "path_child_pairs", block.resource.path_child_pairs)
-		_undo_redo.add_do_property(block.resource, "path_child_pairs", path_child_pairs)
+		undo_redo.add_undo_property(block.resource, "path_child_pairs", block.resource.path_child_pairs)
+		undo_redo.add_do_property(block.resource, "path_child_pairs", path_child_pairs)
 
 	return block.resource
 

--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -186,10 +186,10 @@ func build_tree(block: Block) -> SerializedBlockTreeNode:
 	block.update_resources(_undo_redo)
 
 	for snap in find_snaps(block):
-		for child in snap.get_children():
-			if not child is Block:  # Make sure to not include preview
-				continue
-			path_child_pairs.append([block.get_path_to(snap), build_tree(child)])
+		var snapped_block = snap.get_snapped_block()
+		if snapped_block == null:
+			continue
+		path_child_pairs.append([block.get_path_to(snap), build_tree(snapped_block)])
 
 	if block.resource.path_child_pairs != path_child_pairs:
 		_undo_redo.add_undo_property(block.resource, "path_child_pairs", block.resource.path_child_pairs)
@@ -198,10 +198,10 @@ func build_tree(block: Block) -> SerializedBlockTreeNode:
 	return block.resource
 
 
-func find_snaps(node: Node) -> Array:
-	var snaps := []
+func find_snaps(node: Node) -> Array[SnapPoint]:
+	var snaps: Array[SnapPoint]
 
-	if node.is_in_group("snap_point"):
+	if node.is_in_group("snap_point") and node is SnapPoint:
 		snaps.append(node)
 	else:
 		for c in node.get_children():

--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -174,9 +174,11 @@ func load_tree(parent: Node, node: SerializedBlockTreeNode):
 
 func rebuild_block_trees(undo_redo):
 	_undo_redo = undo_redo
-	_current_bsd.block_trees.array = []
+	var block_trees_array = []
 	for c in _window.get_children():
-		_current_bsd.block_trees.array.append(build_tree(c))
+		block_trees_array.append(build_tree(c))
+	undo_redo.add_undo_property(_current_bsd.block_trees, "array", _current_bsd.block_trees.array)
+	undo_redo.add_do_property(_current_bsd.block_trees, "array", block_trees_array)
 
 
 func build_tree(block: Block) -> SerializedBlockTreeNode:
@@ -191,8 +193,7 @@ func build_tree(block: Block) -> SerializedBlockTreeNode:
 
 	if block.resource.path_child_pairs != path_child_pairs:
 		_undo_redo.add_undo_property(block.resource, "path_child_pairs", block.resource.path_child_pairs)
-		block.resource.path_child_pairs = path_child_pairs
-		_undo_redo.add_do_property(block.resource, "path_child_pairs", block.resource.path_child_pairs)
+		_undo_redo.add_do_property(block.resource, "path_child_pairs", path_child_pairs)
 
 	return block.resource
 

--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -26,6 +26,9 @@ signal modified
 ## The scope of the block (statement of matching entry block)
 @export var scope: String = ""
 
+## The resource containing the block properties and the snapped blocks
+@export var resource: SerializedBlockTreeNode
+
 
 func _ready():
 	mouse_filter = Control.MOUSE_FILTER_IGNORE
@@ -59,6 +62,19 @@ func get_instruction_node() -> InstructionTree.TreeNode:
 			node.next = snapped_block.get_instruction_node()
 
 	return node
+
+
+func update_resources(undo_redo: EditorUndoRedoManager):
+	if resource == null:
+		var serialized_block = SerializedBlock.new(get_block_class(), get_serialized_props())
+		resource = SerializedBlockTreeNode.new(serialized_block)
+		return
+
+	var serialized_props = get_serialized_props()
+	if serialized_props != resource.serialized_block.serialized_props:
+		undo_redo.add_undo_property(resource.serialized_block, "serialized_props", resource.serialized_block.serialized_props)
+		resource.serialized_block.serialized_props = serialized_props
+		undo_redo.add_do_property(resource.serialized_block, "serialized_props", resource.serialized_block.serialized_props)
 
 
 # Override this method to add more serialized properties

--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -73,8 +73,7 @@ func update_resources(undo_redo: EditorUndoRedoManager):
 	var serialized_props = get_serialized_props()
 	if serialized_props != resource.serialized_block.serialized_props:
 		undo_redo.add_undo_property(resource.serialized_block, "serialized_props", resource.serialized_block.serialized_props)
-		resource.serialized_block.serialized_props = serialized_props
-		undo_redo.add_do_property(resource.serialized_block, "serialized_props", resource.serialized_block.serialized_props)
+		undo_redo.add_do_property(resource.serialized_block, "serialized_props", serialized_props)
 
 
 # Override this method to add more serialized properties

--- a/addons/block_code/ui/main_panel.gd
+++ b/addons/block_code/ui/main_panel.gd
@@ -139,17 +139,14 @@ func save_script():
 		_current_block_code_node.block_script = block_script
 		undo_redo.add_do_property(_current_block_code_node, "block_script", _current_block_code_node.block_script)
 
-	undo_redo.add_undo_property(_current_block_code_node.block_script, "block_trees", _current_block_code_node.block_script.block_trees)
-	undo_redo.add_undo_property(_current_block_code_node.block_script, "generated_script", _current_block_code_node.block_script.generated_script)
-
-	var block_trees := _block_canvas.get_canvas_block_trees()
+	_block_canvas.rebuild_block_trees(undo_redo)
 	var generated_script = _block_canvas.generate_script_from_current_window(block_script)
-	block_script.block_trees = block_trees
-	block_script.generated_script = generated_script
+	if generated_script != block_script.generated_script:
+		undo_redo.add_undo_property(_current_block_code_node.block_script, "generated_script", _current_block_code_node.block_script.generated_script)
+		block_script.generated_script = generated_script
+		undo_redo.add_do_property(_current_block_code_node.block_script, "generated_script", _current_block_code_node.block_script.generated_script)
 	block_script.version = Constants.CURRENT_DATA_VERSION
 
-	undo_redo.add_do_property(_current_block_code_node.block_script, "block_trees", block_trees)
-	undo_redo.add_do_property(_current_block_code_node.block_script, "generated_script", generated_script)
 	undo_redo.commit_action()
 
 

--- a/addons/block_code/ui/main_panel.gd
+++ b/addons/block_code/ui/main_panel.gd
@@ -128,7 +128,7 @@ func save_script():
 	var resource_path_split = block_script.resource_path.split("::", true, 1)
 	var resource_scene = resource_path_split[0]
 
-	undo_redo.create_action("Modify %s's block code script" % _current_block_code_node.get_parent().name)
+	undo_redo.create_action("Modify %s's block code script" % _current_block_code_node.get_parent().name, UndoRedo.MERGE_DISABLE, _current_block_code_node)
 
 	if resource_scene and resource_scene != scene_node.scene_file_path:
 		# This resource is from another scene. Since the user is changing it
@@ -136,15 +136,14 @@ func save_script():
 		# other scene file.
 		undo_redo.add_undo_property(_current_block_code_node, "block_script", _current_block_code_node.block_script)
 		block_script = block_script.duplicate(true)
-		_current_block_code_node.block_script = block_script
-		undo_redo.add_do_property(_current_block_code_node, "block_script", _current_block_code_node.block_script)
+		undo_redo.add_do_property(_current_block_code_node, "block_script", block_script)
 
 	_block_canvas.rebuild_block_trees(undo_redo)
 	var generated_script = _block_canvas.generate_script_from_current_window(block_script)
 	if generated_script != block_script.generated_script:
-		undo_redo.add_undo_property(_current_block_code_node.block_script, "generated_script", _current_block_code_node.block_script.generated_script)
-		block_script.generated_script = generated_script
-		undo_redo.add_do_property(_current_block_code_node.block_script, "generated_script", _current_block_code_node.block_script.generated_script)
+		undo_redo.add_undo_property(block_script, "generated_script", block_script.generated_script)
+		undo_redo.add_do_property(block_script, "generated_script", generated_script)
+
 	block_script.version = Constants.CURRENT_DATA_VERSION
 
 	undo_redo.commit_action()


### PR DESCRIPTION
Add a resource property to blocks of type SerializedBlock. The resource will be updated before building the tree.

This mitigates having a huge diff in scenes with blocks for minimum changes like moving a block in the canvas.

https://phabricator.endlessm.com/T35565