### PR TITLE
Parameter input: change text modification logic

### DIFF
--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
@@ -31,6 +31,11 @@ var option: bool = false
 @onready var _bool_input := %BoolInput
 @onready var _bool_input_option := %BoolInputOption
 
+# Used to submit the text when losing focus:
+var _last_lineedit_submitted_text: String
+var _last_x_lineedit_submitted_text: String
+var _last_y_lineedit_submitted_text: String
+
 
 func set_raw_input(raw_input):
 	if option:
@@ -93,6 +98,10 @@ func _ready():
 	snap_point.block_type = block_type
 	snap_point.variant_type = variant_type
 
+	_last_lineedit_submitted_text = _line_edit.text
+	_last_x_lineedit_submitted_text = _x_line_edit.text
+	_last_y_lineedit_submitted_text = _y_line_edit.text
+
 	_update_visible_input()
 
 
@@ -126,8 +135,34 @@ func get_string() -> String:
 			return "%s" % input
 
 
-func _on_line_edit_text_changed(new_text):
+func _on_line_edit_text_submitted(new_text):
+	_last_lineedit_submitted_text = new_text
 	modified.emit()
+
+
+func _on_line_edit_focus_exited():
+	if _last_lineedit_submitted_text != _line_edit.text:
+		modified.emit()
+
+
+func _on_x_line_edit_text_submitted(new_text):
+	_last_x_lineedit_submitted_text = new_text
+	modified.emit()
+
+
+func _on_x_line_edit_focus_exited():
+	if _last_x_lineedit_submitted_text != _x_line_edit.text:
+		modified.emit()
+
+
+func _on_y_line_edit_text_submitted(new_text):
+	_last_y_lineedit_submitted_text = new_text
+	modified.emit()
+
+
+func _on_y_line_edit_focus_exited():
+	if _last_y_lineedit_submitted_text != _y_line_edit.text:
+		modified.emit()
 
 
 func _update_visible_input():

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn
@@ -178,14 +178,16 @@ popup/item_1/id = 1
 [node name="SnapPoint" parent="." instance=ExtResource("2_6esp3")]
 unique_name_in_owner = true
 layout_mode = 2
-mouse_filter = 2
 block_type = 3
 variant_type = 4
 
-[connection signal="text_changed" from="InputSwitcher/TextInput/LineEdit" to="." method="_on_line_edit_text_changed"]
+[connection signal="focus_exited" from="InputSwitcher/TextInput/LineEdit" to="." method="_on_line_edit_focus_exited"]
+[connection signal="text_submitted" from="InputSwitcher/TextInput/LineEdit" to="." method="_on_line_edit_text_submitted"]
 [connection signal="color_changed" from="InputSwitcher/ColorInput" to="." method="_on_color_input_color_changed"]
 [connection signal="item_selected" from="InputSwitcher/OptionInput" to="." method="_on_option_input_item_selected"]
-[connection signal="text_changed" from="InputSwitcher/Vector2Input/HBoxContainer/XLineEdit" to="." method="_on_line_edit_text_changed"]
-[connection signal="text_changed" from="InputSwitcher/Vector2Input/HBoxContainer/YLineEdit" to="." method="_on_line_edit_text_changed"]
+[connection signal="focus_exited" from="InputSwitcher/Vector2Input/HBoxContainer/XLineEdit" to="." method="_on_x_line_edit_focus_exited"]
+[connection signal="text_submitted" from="InputSwitcher/Vector2Input/HBoxContainer/XLineEdit" to="." method="_on_x_line_edit_text_submitted"]
+[connection signal="focus_exited" from="InputSwitcher/Vector2Input/HBoxContainer/YLineEdit" to="." method="_on_y_line_edit_focus_exited"]
+[connection signal="text_submitted" from="InputSwitcher/Vector2Input/HBoxContainer/YLineEdit" to="." method="_on_y_line_edit_text_submitted"]
 [connection signal="item_selected" from="InputSwitcher/BoolInput/BoolInputOption" to="." method="_on_option_input_item_selected"]
 [connection signal="snapped_block_changed" from="SnapPoint" to="." method="_on_snap_point_snapped_block_changed"]


### PR DESCRIPTION
Previously any text change was sending the modified signal, adding too many actions to the undo/redo history (one per typed character). This was also capturing shortcuts like Ctrl-Z for undoing and sending the modified signal, thus piling to the history, not going back.

Instead, send the modified signal when the line edit is submitted (enter key pressed) or when it loses focus and the text has changed.

https://phabricator.endlessm.com/T35566