### PR TITLE
Reinstate stylebox overrides

### DIFF
--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
@@ -1,7 +1,18 @@
-[gd_scene load_steps=3 format=3 uid="uid://clipm2dd28jde"]
+[gd_scene load_steps=4 format=3 uid="uid://clipm2dd28jde"]
 
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/parameter_block/parameter_block.gd" id="1_0hajy"]
 [ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="2_gy5co"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dbera"]
+bg_color = Color(1, 1, 1, 1)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+corner_radius_top_left = 16
+corner_radius_top_right = 16
+corner_radius_bottom_right = 16
+corner_radius_bottom_left = 16
 
 [node name="ParameterBlock" type="MarginContainer"]
 offset_right = 16.0
@@ -16,6 +27,7 @@ block_type = 3
 [node name="Panel" type="Panel" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_dbera")
 
 [node name="DragDropArea" parent="." instance=ExtResource("2_gy5co")]
 layout_mode = 2

--- a/addons/block_code/ui/picker/categories/block_category_button.tscn
+++ b/addons/block_code/ui/picker/categories/block_category_button.tscn
@@ -1,6 +1,13 @@
-[gd_scene load_steps=6 format=3 uid="uid://bdtetj0gs45hv"]
+[gd_scene load_steps=7 format=3 uid="uid://bdtetj0gs45hv"]
 
 [ext_resource type="Script" path="res://addons/block_code/ui/picker/categories/block_category_button.gd" id="1_pxxnl"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_eogpc"]
+bg_color = Color(1, 0, 0, 1)
+corner_radius_top_left = 100
+corner_radius_top_right = 100
+corner_radius_bottom_right = 100
+corner_radius_bottom_left = 100
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_ousiv"]
 
@@ -32,6 +39,7 @@ theme_override_constants/margin_bottom = 8
 [node name="Panel" type="Panel" parent="HBoxContainer/MarginContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_eogpc")
 
 [node name="Label" type="Label" parent="HBoxContainer"]
 unique_name_in_owner = true


### PR DESCRIPTION
This partially reverts commit 1b6d64b4f6d532139e29acb0d1cf9c4824ac9ced (“Don't recreate resources when editing plugin scenes”).

I incorrectly believed that these were being fully recreated every time the scene is instantiated based on another element's stylebox, but in fact they are being used as a template and it is only the colour that is being adjusted.

See discussion at https://github.com/endlessm/godot-block-coding/pull/138#discussion_r1681557942.