### PR TITLE
Plugin: Only skip duplicate work when BlockCode nodes selected

### DIFF
--- a/addons/block_code/block_code_plugin.gd
+++ b/addons/block_code/block_code_plugin.gd
@@ -138,7 +138,10 @@ func _on_editor_inspector_edited_object_changed():
 
 
 func select_block_code_node(block_code: BlockCode):
-	if block_code == _selected_block_code:
+	# Skip duplicate selection unless new node is null. That happens when any
+	# non-BlockCode node is selected and that needs to be passed through to the
+	# main panel.
+	if block_code and block_code == _selected_block_code:
 		return
 
 	if not is_block_code_editable(block_code):


### PR DESCRIPTION
In dbd7643, an early return was added to avoid updating the UI when the same BlockCode node has been selected. When a non-BlockCode has been selected, the main panel needs to be told about it so that it can show some friendly messages about adding a BlockCode node. However, any non-BlockCode node is represented as null, which means that changes to a selected non-BlockCode node can't be differentiated. Skip the early return in that case.

https://phabricator.endlessm.com/T35572