### PR TITLE
BlockCanvas: Fix block node array typing

### DIFF
--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -172,7 +172,7 @@ func load_tree(parent: Node, node: SerializedBlockTreeNode):
 
 
 func rebuild_block_trees(undo_redo):
-	var block_trees_array = []
+	var block_trees_array: Array[SerializedBlockTreeNode]
 	for c in _window.get_children():
 		block_trees_array.append(build_tree(c, undo_redo))
 	undo_redo.add_undo_property(_current_bsd.block_trees, "array", _current_bsd.block_trees.array)


### PR DESCRIPTION
Prior to 01ab76c, the block trees array was modified in place, which meant is was correctly typed as `Array[SerializedBlockTreeNode]`. Now it's being built from an untyped array, which breaks script generation.

https://phabricator.endlessm.com/T35573