### PR TITLE
ci: Use asset lib action 0.6.0

### DIFF
--- a/.github/workflows/godot-asset-library.yaml
+++ b/.github/workflows/godot-asset-library.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Push to Godot Asset Library
-        uses: wjt/godot-asset-lib-action@9cce3792b504bec69eb06b852b008d095e372f56
+        uses: deep-entertainment/godot-asset-lib-action@v0.6.0
         with:
           username: ${{ secrets.GODOT_ASSET_LIBRARY_USERNAME }}
           password: ${{ secrets.GODOT_ASSET_LIBRARY_PASSWORD }}


### PR DESCRIPTION
All my PRs were merged & released so this is equivalent to the version we have been using from my fork.