### PR TITLE
Util: Make node_is_part_of_edited_scene safer

### DIFF
--- a/addons/block_code/ui/util.gd
+++ b/addons/block_code/ui/util.gd
@@ -3,4 +3,12 @@ extends Object
 
 ## Polyfill of Node.is_part_of_edited_scene(), available to GDScript in Godot 4.3+.
 static func node_is_part_of_edited_scene(node: Node) -> bool:
-	return Engine.is_editor_hint() && node.is_inside_tree() && node.get_tree().edited_scene_root && node.get_tree().edited_scene_root.get_parent().is_ancestor_of(node)
+	if not Engine.is_editor_hint():
+		return false
+
+	var tree := node.get_tree()
+	if not tree or not tree.edited_scene_root:
+		return false
+
+	var edited_scene_parent := tree.edited_scene_root.get_parent()
+	return edited_scene_parent and edited_scene_parent.is_ancestor_of(node)


### PR DESCRIPTION
When switching to a different scene in the editor, the previous edited scene root will no longer have a parent and you'll see a pile of "Cannot call method 'is_ancestor_of' on a null value." errors from Godot. Unroll the one liner to add the parent null check and use some intermediate variables to remove duplicate method calls. Note that the is_inside_tree() call is dropped since it's redundant to checking if get_tree() returns null.