### PR TITLE
Block: Allow deleting with Delete button

### DIFF
--- a/addons/block_code/drag_manager/drag.gd
+++ b/addons/block_code/drag_manager/drag.gd
@@ -34,7 +34,7 @@ var target_snap_point: SnapPoint:
 
 var snap_block: Block:
 	get:
-		return target_snap_point.get_parent_block() if target_snap_point else null
+		return BlockTreeUtil.get_parent_block(target_snap_point) if target_snap_point else null
 
 
 func _init(block: Block, block_scope: String, offset: Vector2, block_canvas: BlockCanvas):

--- a/addons/block_code/drag_manager/drag_manager.gd
+++ b/addons/block_code/drag_manager/drag_manager.gd
@@ -80,6 +80,7 @@ func drag_ended():
 
 	if block:
 		connect_block_canvas_signals(block)
+		block.grab_focus()
 
 	_block_canvas.release_scope()
 

--- a/addons/block_code/drag_manager/drag_manager.gd
+++ b/addons/block_code/drag_manager/drag_manager.gd
@@ -82,6 +82,9 @@ func drag_ended():
 		connect_block_canvas_signals(block)
 		block.grab_focus()
 
+		# Allow the block to be deleted now that it's on the canvas.
+		block.can_delete = true
+
 	_block_canvas.release_scope()
 
 	drag.queue_free()

--- a/addons/block_code/ui/block_tree_util.gd
+++ b/addons/block_code/ui/block_tree_util.gd
@@ -78,3 +78,11 @@ static func get_tree_scope(node: Node) -> String:
 		if scope != "":
 			return scope
 	return ""
+
+
+## Get the nearest Block node that is a parent of the provided node.
+static func get_parent_block(node: Node) -> Block:
+	var parent = node.get_parent()
+	while parent and not parent is Block:
+		parent = parent.get_parent()
+	return parent as Block

--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -48,6 +48,7 @@ func _set_bottom_snap_path(value: NodePath):
 func _ready():
 	if bottom_snap == null:
 		_set_bottom_snap_path(bottom_snap_path)
+	focus_mode = FocusMode.FOCUS_ALL
 	mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 

--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -39,6 +39,9 @@ signal modified
 # https://github.com/godotengine/godot/issues/82670
 var bottom_snap: SnapPoint
 
+## Whether the block can be deleted by the Delete key.
+var can_delete: bool = true
+
 
 func _set_bottom_snap_path(value: NodePath):
 	bottom_snap_path = value
@@ -50,6 +53,36 @@ func _ready():
 		_set_bottom_snap_path(bottom_snap_path)
 	focus_mode = FocusMode.FOCUS_ALL
 	mouse_filter = Control.MOUSE_FILTER_IGNORE
+
+
+func _gui_input(event):
+	if event is InputEventKey:
+		if event.pressed and event.keycode == KEY_DELETE:
+			# Always accept the Delete key so it doesn't propagate to the
+			# BlockCode node in the scene tree.
+			accept_event()
+
+			if not can_delete:
+				return
+
+			var dialog := ConfirmationDialog.new()
+			var num_blocks = _count_child_blocks(self) + 1
+			# FIXME: Maybe this should use block_name or label, but that
+			# requires one to be both unique and human friendly.
+			if num_blocks > 1:
+				dialog.dialog_text = "Delete %d blocks?" % num_blocks
+			else:
+				dialog.dialog_text = "Delete block?"
+			dialog.confirmed.connect(remove_from_tree)
+			EditorInterface.popup_dialog_centered(dialog)
+
+
+func remove_from_tree():
+	var parent = get_parent()
+	if parent:
+		parent.remove_child(self)
+	queue_free()
+	modified.emit()
 
 
 static func get_block_class():
@@ -125,3 +158,14 @@ func _make_custom_tooltip(for_text) -> Control:
 	var tooltip = preload("res://addons/block_code/ui/tooltip/tooltip.tscn").instantiate()
 	tooltip.text = for_text
 	return tooltip
+
+
+func _count_child_blocks(node: Node) -> int:
+	var count = 0
+
+	for child in node.get_children():
+		if child is SnapPoint and child.has_snapped_block():
+			count += 1
+		count += _count_child_blocks(child)
+
+	return count

--- a/addons/block_code/ui/blocks/control_block/control_block.tscn
+++ b/addons/block_code/ui/blocks/control_block/control_block.tscn
@@ -5,6 +5,7 @@
 
 [node name="ControlBlock" type="MarginContainer"]
 size_flags_horizontal = 0
+focus_mode = 2
 mouse_filter = 2
 script = ExtResource("1_2hbir")
 block_name = &"control_block"

--- a/addons/block_code/ui/blocks/entry_block/entry_block.tscn
+++ b/addons/block_code/ui/blocks/entry_block/entry_block.tscn
@@ -4,6 +4,7 @@
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/entry_block/entry_block.gd" id="2_3ik8h"]
 
 [node name="EntryBlock" instance=ExtResource("1_byjbb")]
+focus_mode = 2
 script = ExtResource("2_3ik8h")
 signal_name = ""
 block_name = &"entry_block"

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.gd
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.gd
@@ -2,6 +2,7 @@
 class_name ParameterBlock
 extends Block
 
+const Constants = preload("res://addons/block_code/ui/constants.gd")
 const Util = preload("res://addons/block_code/ui/util.gd")
 
 @export var block_format: String = ""
@@ -16,16 +17,24 @@ var param_name_input_pairs: Array
 var param_input_strings: Dictionary  # Only loaded from serialized
 var spawned_by: ParameterOutput
 
+var _panel_normal: StyleBox
+var _panel_focus: StyleBox
+
 
 func _ready():
 	super()
 
+	_panel_normal = _panel.get_theme_stylebox("panel").duplicate()
+	_panel_normal.bg_color = color
+	_panel_normal.border_color = color.darkened(0.2)
+
+	_panel_focus = _panel.get_theme_stylebox("panel").duplicate()
+	_panel_focus.bg_color = color
+	_panel_focus.border_color = Constants.FOCUS_BORDER_COLOR
+
 	block_type = Types.BlockType.VALUE
 	if not Util.node_is_part_of_edited_scene(self):
-		var new_panel = _panel.get_theme_stylebox("panel").duplicate()
-		new_panel.bg_color = color
-		new_panel.border_color = color.darkened(0.2)
-		_panel.add_theme_stylebox_override("panel", new_panel)
+		_panel.add_theme_stylebox_override("panel", _panel_normal)
 
 	format()
 
@@ -73,3 +82,11 @@ static func get_scene_path():
 
 func format():
 	param_name_input_pairs = StatementBlock.format_string(self, %HBoxContainer, block_format, defaults)
+
+
+func _on_focus_entered():
+	_panel.add_theme_stylebox_override("panel", _panel_focus)
+
+
+func _on_focus_exited():
+	_panel.add_theme_stylebox_override("panel", _panel_normal)

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
@@ -47,4 +47,6 @@ unique_name_in_owner = true
 layout_mode = 2
 mouse_filter = 2
 
+[connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
+[connection signal="focus_exited" from="." to="." method="_on_focus_exited"]
 [connection signal="mouse_down" from="DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
@@ -18,6 +18,7 @@ corner_radius_bottom_left = 16
 offset_right = 16.0
 offset_bottom = 8.0
 size_flags_horizontal = 0
+focus_mode = 2
 mouse_filter = 2
 script = ExtResource("1_0hajy")
 block_name = &"parameter_block"

--- a/addons/block_code/ui/blocks/statement_block/statement_block.tscn
+++ b/addons/block_code/ui/blocks/statement_block/statement_block.tscn
@@ -7,6 +7,7 @@
 
 [node name="StatementBlock" type="MarginContainer"]
 size_flags_horizontal = 0
+focus_mode = 2
 mouse_filter = 2
 script = ExtResource("1_6wvlf")
 block_name = &"statement_block"

--- a/addons/block_code/ui/blocks/utilities/background/background.gd
+++ b/addons/block_code/ui/blocks/utilities/background/background.gd
@@ -1,9 +1,11 @@
 @tool
 extends Control
 
+const BlockTreeUtil = preload("res://addons/block_code/ui/block_tree_util.gd")
 const Constants = preload("res://addons/block_code/ui/constants.gd")
 
 var outline_color: Color
+var parent_block: Block
 
 @export var color: Color:
 	set = _set_color
@@ -39,6 +41,12 @@ func _set_shift_top(new_shift_top):
 func _set_shift_bottom(new_shift_bottom):
 	shift_bottom = new_shift_bottom
 	queue_redraw()
+
+
+func _ready():
+	parent_block = BlockTreeUtil.get_parent_block(self)
+	parent_block.focus_entered.connect(queue_redraw)
+	parent_block.focus_exited.connect(queue_redraw)
 
 
 func _draw():
@@ -97,5 +105,5 @@ func _draw():
 		edge_polygon.append(Vector2(0.0, size.y + outline_middle))
 
 	draw_colored_polygon(fill_polygon, color)
-	draw_polyline(stroke_polygon, outline_color, Constants.OUTLINE_WIDTH)
-	draw_polyline(edge_polygon, outline_color, Constants.OUTLINE_WIDTH)
+	draw_polyline(stroke_polygon, Constants.FOCUS_BORDER_COLOR if parent_block.has_focus() else outline_color, Constants.OUTLINE_WIDTH)
+	draw_polyline(edge_polygon, Constants.FOCUS_BORDER_COLOR if parent_block.has_focus() else outline_color, Constants.OUTLINE_WIDTH)

--- a/addons/block_code/ui/blocks/utilities/background/gutter.gd
+++ b/addons/block_code/ui/blocks/utilities/background/gutter.gd
@@ -1,9 +1,11 @@
 @tool
 extends Control
 
+const BlockTreeUtil = preload("res://addons/block_code/ui/block_tree_util.gd")
 const Constants = preload("res://addons/block_code/ui/constants.gd")
 
 var outline_color: Color
+var parent_block: Block
 
 @export var color: Color:
 	set = _set_color
@@ -13,6 +15,12 @@ func _set_color(new_color):
 	color = new_color
 	outline_color = color.darkened(0.2)
 	queue_redraw()
+
+
+func _ready():
+	parent_block = BlockTreeUtil.get_parent_block(self)
+	parent_block.focus_entered.connect(queue_redraw)
+	parent_block.focus_exited.connect(queue_redraw)
 
 
 func _draw():
@@ -33,5 +41,5 @@ func _draw():
 	right_polygon.append(Vector2(size.x, size.y))
 
 	draw_colored_polygon(fill_polygon, color)
-	draw_polyline(left_polygon, outline_color, Constants.OUTLINE_WIDTH)
-	draw_polyline(right_polygon, outline_color, Constants.OUTLINE_WIDTH)
+	draw_polyline(left_polygon, Constants.FOCUS_BORDER_COLOR if parent_block.has_focus() else outline_color, Constants.OUTLINE_WIDTH)
+	draw_polyline(right_polygon, Constants.FOCUS_BORDER_COLOR if parent_block.has_focus() else outline_color, Constants.OUTLINE_WIDTH)

--- a/addons/block_code/ui/blocks/utilities/snap_point/snap_point.gd
+++ b/addons/block_code/ui/blocks/utilities/snap_point/snap_point.gd
@@ -29,13 +29,6 @@ func _ready():
 	_update_snapped_block_from_children()
 
 
-func get_parent_block() -> Block:
-	var parent = get_parent()
-	while parent and not parent is Block:
-		parent = parent.get_parent()
-	return parent as Block
-
-
 func _update_snapped_block_from_children():
 	# Temporary migration to set the snapped_block property based on children
 	# of this node.

--- a/addons/block_code/ui/constants.gd
+++ b/addons/block_code/ui/constants.gd
@@ -9,3 +9,5 @@ const KNOB_Z = 5.0
 const CONTROL_MARGIN = 20.0
 const OUTLINE_WIDTH = 3.0
 const MINIMUM_SNAP_DISTANCE = 80.0
+
+const FOCUS_BORDER_COLOR = Color(225, 242, 0)

--- a/addons/block_code/ui/picker/picker.gd
+++ b/addons/block_code/ui/picker/picker.gd
@@ -85,6 +85,9 @@ func init_picker(extra_blocks: Array[Block] = [], extra_categories: Array[BlockC
 			var block: Block = _block as Block
 			block.drag_started.connect(_block_picked)
 
+			# Don't allow the block to be deleted while in the picker.
+			block.can_delete = false
+
 		_block_scroll.scroll_vertical = 0
 
 


### PR DESCRIPTION
Allow a Block to be deleted with a confirmation dialog when the Delete
key is pressed. However, when the Block is in the picker (rather than
the canvas), it shouldn't be deleted. Add a flag to disable deleting and
restore it when a drag completes. Furthermore, when it shouldn't be
deleted, stop propagating the Delete key so it doesn't try to delete the
whole BlockCode node.

Fixes: #162