### PR TITLE
Block: Set bottom_snap_path when ready

### DIFF
--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -45,6 +45,8 @@ func _set_bottom_snap_path(value: NodePath):
 
 
 func _ready():
+	if bottom_snap == null:
+		_set_bottom_snap_path(bottom_snap_path)
 	mouse_filter = Control.MOUSE_FILTER_IGNORE
 
 


### PR DESCRIPTION
The bottom_snap must be set on ready, regardless of previously setting it.

Regression from 9aae2bb6

Fixes: #172