### PR TITLE
Block Canvas: Reuse saved block scene resource

### DIFF
--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -164,6 +164,7 @@ func load_tree(parent: Node, node: SerializedBlockTreeNode):
 	var scene: Block = load(_block_scene_path).instantiate()
 	for prop_pair in node.serialized_block.serialized_props:
 		scene.set(prop_pair[0], prop_pair[1])
+	scene.resource = node
 	parent.add_child(scene)
 
 	var scene_block: Block = scene as Block


### PR DESCRIPTION
By simply assigning it to the scene resource property when loading the tree.

Follow up of 01ab76c5 which already removed all resource regeneration except when loading the canvas.