### PR TITLE
statement_block: "Load" a scene as a node instead of "preload"

### DIFF
--- a/addons/block_code/simple_nodes/simple_character/_simple_character.tscn
+++ b/addons/block_code/simple_nodes/simple_character/_simple_character.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://addons/block_code/simple_nodes/simple_character/_simple_character.gd" id="1_idjqv"]
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_ffh0f"]
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_jpheu"]
 size = Vector2(100, 100)
 
 [node name="SimpleCharacter" type="CharacterBody2D"]
@@ -11,4 +11,4 @@ script = ExtResource("1_idjqv")
 [node name="Sprite2D" type="Sprite2D" parent="."]
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource("RectangleShape2D_ffh0f")
+shape = SubResource("RectangleShape2D_jpheu")

--- a/addons/block_code/ui/blocks/statement_block/statement_block.gd
+++ b/addons/block_code/ui/blocks/statement_block/statement_block.gd
@@ -3,7 +3,6 @@ class_name StatementBlock
 extends Block
 
 const ParameterInput = preload("res://addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd")
-const ParameterInputScene = preload("res://addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn")
 
 @export var block_format: String = ""
 @export var statement: String = ""
@@ -121,7 +120,7 @@ static func format_string(parent_block: Block, attach_to: Node, string: String, 
 		var param_node: Node
 
 		if copy_block:
-			var parameter_output: ParameterOutput = preload("res://addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.tscn").instantiate()
+			var parameter_output: ParameterOutput = load("res://addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.tscn").instantiate()
 			parameter_output.name = "ParameterOutput%d" % start  # Unique path
 			parameter_output.block_params = {
 				"block_format": param_name,
@@ -133,7 +132,7 @@ static func format_string(parent_block: Block, attach_to: Node, string: String, 
 			parameter_output.block = parent_block
 			attach_to.add_child(parameter_output)
 		else:
-			var parameter_input: ParameterInput = ParameterInputScene.instantiate()
+			var parameter_input: ParameterInput = load("res://addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn").instantiate()
 			parameter_input.name = "ParameterInput%d" % start  # Unique path
 			parameter_input.placeholder = param_name
 			if param_type != null:


### PR DESCRIPTION
Preloading a scene may be failed, because Godot engine has not prepared the resource ready. And, shows "Parse Error: [ext_resource] referenced non-existent" error [1]:
```
E 0:00:00:0415   _parse_ext_resource: res://addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn:178 - Parse Error: [ext_resource] referenced non-existent resource at: res://addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn
  <C++ Source>   scene/resources/resource_format_text.cpp:163 @ _parse_ext_resource()
E 0:00:00:0430   _parse_ext_resource: res://addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.tscn:30 - Parse Error: [ext_resource] referenced non-existent resource at: res://addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn
  <C++ Source>   scene/resources/resource_format_text.cpp:163 @ _parse_ext_resource()
```
So, use load() to replace preload() the scene.

[1]: https://github.com/endlessm/godot-block-coding/pull/174#issuecomment-2257593132