### PR TITLE
Zoom label enhancements

### DIFF
--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -31,7 +31,7 @@ const ZOOM_FACTOR: float = 1.1
 @onready var _open_scene_icon = _open_scene_button.get_theme_icon("Load", "EditorIcons")
 
 @onready var _mouse_override: Control = %MouseOverride
-@onready var _zoom_label: Label = %ZoomLabel
+@onready var _zoom_button: Button = %ZoomButton
 
 var _current_block_script: BlockScriptSerialization
 var _block_scenes_by_class = {}
@@ -39,7 +39,7 @@ var _panning := false
 var zoom: float:
 	set(value):
 		_window.scale = Vector2(value, value)
-		_zoom_label.text = "%.1fx" % value
+		_zoom_button.text = "%.1fx" % value
 	get:
 		return _window.scale.x
 
@@ -106,7 +106,7 @@ func block_script_selected(block_script: BlockScriptSerialization):
 		zoom = 1
 
 	_window.visible = false
-	_zoom_label.visible = false
+	_zoom_button.visible = false
 
 	_empty_box.visible = false
 	_selected_node_box.visible = false
@@ -118,7 +118,7 @@ func block_script_selected(block_script: BlockScriptSerialization):
 	if block_script != null:
 		_load_block_script(block_script)
 		_window.visible = true
-		_zoom_label.visible = true
+		_zoom_button.visible = true
 
 		if block_script != _current_block_script:
 			reset_window_position()
@@ -322,3 +322,8 @@ func set_mouse_override(override: bool):
 func generate_script_from_current_window(block_script: BlockScriptSerialization) -> String:
 	# TODO: implement multiple windows
 	return BlockTreeUtil.generate_script_from_nodes(_window.get_children(), block_script)
+
+
+func _on_zoom_button_pressed():
+	zoom = 1.0
+	reset_window_position()

--- a/addons/block_code/ui/block_canvas/block_canvas.tscn
+++ b/addons/block_code/ui/block_canvas/block_canvas.tscn
@@ -60,8 +60,8 @@ theme_override_constants/margin_bottom = 4
 
 [node name="ZoomLabel" type="Label" parent="WindowContainer/Overlay/MarginContainer"]
 unique_name_in_owner = true
+modulate = Color(1, 1, 1, 0.470588)
 layout_mode = 2
-theme_override_colors/font_color = Color(1, 1, 1, 0.196078)
 theme_override_font_sizes/font_size = 24
 text = "1x"
 horizontal_alignment = 2

--- a/addons/block_code/ui/block_canvas/block_canvas.tscn
+++ b/addons/block_code/ui/block_canvas/block_canvas.tscn
@@ -58,13 +58,12 @@ theme_override_constants/margin_top = 4
 theme_override_constants/margin_right = 4
 theme_override_constants/margin_bottom = 4
 
-[node name="ZoomLabel" type="Label" parent="WindowContainer/Overlay/MarginContainer"]
+[node name="ZoomButton" type="Button" parent="WindowContainer/Overlay/MarginContainer"]
 unique_name_in_owner = true
 modulate = Color(1, 1, 1, 0.470588)
 layout_mode = 2
+focus_mode = 0
 theme_override_font_sizes/font_size = 24
-text = "1x"
-horizontal_alignment = 2
 
 [node name="MouseOverride" type="MarginContainer" parent="."]
 unique_name_in_owner = true
@@ -139,6 +138,7 @@ theme_type_variation = &"InspectorActionButton"
 text = "Override Block Code"
 icon = ExtResource("2_710vn")
 
+[connection signal="pressed" from="WindowContainer/Overlay/MarginContainer/ZoomButton" to="." method="_on_zoom_button_pressed"]
 [connection signal="pressed" from="SelectedNodeBox/ButtonsBox/AddBlockCodeButton" to="." method="_on_add_block_code_button_pressed"]
 [connection signal="pressed" from="SelectedNodeWithBlockCodeBox/ButtonsBox/OpenSceneButton" to="." method="_on_open_scene_button_pressed"]
 [connection signal="pressed" from="SelectedNodeWithBlockCodeBox/ButtonsBox/ReplaceBlockCodeButton" to="." method="_on_replace_block_code_button_pressed"]


### PR DESCRIPTION
For https://github.com/endlessm/godot-block-coding/issues/186, this adds a feature which resets the editor zoom level and scroll position when the user clicks the zoom label (now button) in the bottom right corner. This is consistent with the zoom button in Godot's 2D editor, although for our purpose I felt better about _always_ resetting the scroll position.

For https://github.com/endlessm/godot-block-coding/issues/187, this changes the zoom label to use `CanvasItem.modulate` instead of overriding the text colour.