### PR TITLE
T35591 Read block definition from resource files

### DIFF
--- a/addons/block_code/blocks/lifecycle/physics_process.tres
+++ b/addons/block_code/blocks/lifecycle/physics_process.tres
@@ -5,11 +5,12 @@
 [resource]
 script = ExtResource("1_s0hq0")
 name = &"physics_process"
+description = "Attached blocks will be executed during the \"physics\" processing step of the main loop"
+category = "Lifecycle"
 type = 1
 variant_type = 0
 display_template = "On Physics Process"
 code_template = "func _physics_process(delta):"
-description = "The following will be executed during the \"physics\" processing step of the main loop"
-category = "Lifecycle"
 defaults = {}
 signal_name = ""
+scope = ""

--- a/addons/block_code/blocks/lifecycle/process.tres
+++ b/addons/block_code/blocks/lifecycle/process.tres
@@ -5,11 +5,12 @@
 [resource]
 script = ExtResource("1_pmina")
 name = &"process"
+description = "Attached blocks will be executed during the processing step of the main loop"
+category = "Lifecycle"
 type = 1
 variant_type = 0
 display_template = "On Process"
 code_template = "func _process(delta):"
-description = "The following will be executed during the processing step of the main loop"
-category = "Lifecycle"
 defaults = {}
 signal_name = ""
+scope = ""

--- a/addons/block_code/blocks/lifecycle/ready.tres
+++ b/addons/block_code/blocks/lifecycle/ready.tres
@@ -5,11 +5,12 @@
 [resource]
 script = ExtResource("1_vk0xk")
 name = &"ready"
+description = "Attached blocks will be executed once when the node is \"ready\""
+category = "Lifecycle"
 type = 1
 variant_type = 0
 display_template = "On Ready"
 code_template = "func _ready():"
-description = "The following will be executed when the node is \"ready\""
-category = "Lifecycle"
 defaults = {}
 signal_name = ""
+scope = ""

--- a/addons/block_code/blocks/log/print.tres
+++ b/addons/block_code/blocks/log/print.tres
@@ -11,6 +11,8 @@ type = 2
 variant_type = 0
 display_template = "Print {text: STRING}"
 code_template = "print({text})"
-defaults = {}
+defaults = {
+"text": "Hello"
+}
 signal_name = ""
 scope = ""

--- a/addons/block_code/blocks/loops/for.tres
+++ b/addons/block_code/blocks/loops/for.tres
@@ -5,11 +5,12 @@
 [resource]
 script = ExtResource("1_u01bi")
 name = &"for"
+description = "Run the connected blocks [i]number[/i] times"
+category = "Loops"
 type = 4
 variant_type = 0
-display_template = "Repeat {n: INT}"
-code_template = "for __i in {n}:"
-description = "Run the connected blocks [i]n[/i] times"
-category = "Loops"
+display_template = "Repeat {number: INT}"
+code_template = "for __i in {number}:"
 defaults = {}
 signal_name = ""
+scope = ""

--- a/addons/block_code/blocks/loops/while.tres
+++ b/addons/block_code/blocks/loops/while.tres
@@ -5,11 +5,14 @@
 [resource]
 script = ExtResource("1_fxxh0")
 name = &"while"
+description = "Run the connected blocks as long as [i]condition[/i] is true.
+
+Hint: snap a [b]Comparison[/b] block into the condition."
+category = "Loops"
 type = 4
 variant_type = 0
 display_template = "While {condition: BOOL}"
 code_template = "while {condition}:"
-description = "Run the connected blocks as long as [i]condition[/i] is true.\\nHint: snap a [b]Comparison[/b] block into the condition."
-category = "Loops"
 defaults = {}
 signal_name = ""
+scope = ""

--- a/addons/block_code/code_generation/block_definition.gd
+++ b/addons/block_code/code_generation/block_definition.gd
@@ -5,14 +5,14 @@ extends Resource
 const Types = preload("res://addons/block_code/types/types.gd")
 
 @export var name: StringName
-@export var description: String
+@export_multiline var description: String
 @export var category: String
 
 @export var type: Types.BlockType
 @export var variant_type: Variant.Type
 
 @export var display_template: String
-@export var code_template: String
+@export_multiline var code_template: String
 @export var defaults: Dictionary
 
 ## Only for blocks of type Types.ENTRY. If non-empty, this block defines a

--- a/addons/block_code/code_generation/blocks_catalog.gd
+++ b/addons/block_code/code_generation/blocks_catalog.gd
@@ -2,6 +2,9 @@ extends Object
 
 const BlockDefinition = preload("res://addons/block_code/code_generation/block_definition.gd")
 const Types = preload("res://addons/block_code/types/types.gd")
+const Util = preload("res://addons/block_code/code_generation/util.gd")
+
+const _BLOCKS_PATH = "res://addons/block_code/blocks/"
 
 static var _catalog: Dictionary
 
@@ -11,24 +14,11 @@ static func setup():
 		return
 
 	_catalog = {}
-	var block_definition: BlockDefinition = BlockDefinition.new()
-	block_definition.name = &"ready_block"
-	block_definition.type = Types.BlockType.ENTRY
-	block_definition.display_template = "On Ready"
-	block_definition.code_template = "func _ready():"
-	block_definition.description = 'Attached blocks will be executed once when the node is "ready"'
-	block_definition.category = "Lifecycle"
-	_catalog[&"ready_block"] = block_definition
 
-	block_definition = BlockDefinition.new()
-	block_definition.name = &"print"
-	block_definition.type = Types.BlockType.STATEMENT
-	block_definition.display_template = "print {text: STRING}"
-	block_definition.code_template = "print({text})"
-	block_definition.defaults = {"text": "Hello"}
-	block_definition.description = "Print the text to output"
-	block_definition.category = "Log"
-	_catalog[&"print"] = block_definition
+	var definition_files = Util.get_files_in_dir_recursive(_BLOCKS_PATH, "*.tres")
+	for file in definition_files:
+		var block_definition = load(file)
+		_catalog[block_definition.name] = block_definition
 
 
 static func get_block(block_name: StringName):

--- a/addons/block_code/code_generation/util.gd
+++ b/addons/block_code/code_generation/util.gd
@@ -1,0 +1,24 @@
+extends Object
+
+
+static func get_files_in_dir_recursive(path: String, pattern: String) -> Array:
+	var files = []
+	var dir := DirAccess.open(path)
+
+	if not dir:
+		return files
+
+	dir.list_dir_begin()
+
+	var file_name = dir.get_next()
+
+	while file_name != "":
+		var file_path = path + "/" + file_name
+		if dir.current_is_dir():
+			files.append_array(get_files_in_dir_recursive(file_path, pattern))
+		elif file_name.matchn(pattern):
+			files.append(file_path)
+
+		file_name = dir.get_next()
+
+	return files

--- a/addons/block_code/examples/pong_game/pong_game.tscn
+++ b/addons/block_code/examples/pong_game/pong_game.tscn
@@ -35,7 +35,7 @@ serialized_props = [["color", Color(0.92549, 0.231373, 0.34902, 1)], ["scope", "
 
 [sub_resource type="Resource" id="Resource_yiq7s"]
 script = ExtResource("4_qtggh")
-name = &"ready_block"
+name = &"ready"
 position = Vector2(75, 175)
 path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_q65fe")]]
 block_serialized_properties = SubResource("Resource_q1vhx")
@@ -130,7 +130,7 @@ serialized_props = [["color", Color(0.92549, 0.231373, 0.34902, 1)], ["scope", "
 
 [sub_resource type="Resource" id="Resource_hrubs"]
 script = ExtResource("4_qtggh")
-name = &"ready_block"
+name = &"ready"
 position = Vector2(50, 175)
 path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_ttkrd")]]
 block_serialized_properties = SubResource("Resource_06s7w")
@@ -269,7 +269,7 @@ serialized_props = [["color", Color(0.92549, 0.231373, 0.34902, 1)], ["scope", "
 
 [sub_resource type="Resource" id="Resource_1h6wi"]
 script = ExtResource("4_qtggh")
-name = &"ready_block"
+name = &"ready"
 position = Vector2(54, 47)
 path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_gywyt")]]
 block_serialized_properties = SubResource("Resource_b0aen")
@@ -862,7 +862,7 @@ serialized_props = [["color", Color(0.92549, 0.231373, 0.34902, 1)], ["scope", "
 
 [sub_resource type="Resource" id="Resource_njwj4"]
 script = ExtResource("4_qtggh")
-name = &"ready_block"
+name = &"ready"
 position = Vector2(54, 47)
 path_child_pairs = [[NodePath("VBoxContainer/SnapPoint"), SubResource("Resource_8xxm3")]]
 block_serialized_properties = SubResource("Resource_g3mty")

--- a/addons/block_code/serialization/default_block_script.tres
+++ b/addons/block_code/serialization/default_block_script.tres
@@ -11,7 +11,7 @@ serialized_props = [["color", Color(0.92549, 0.231373, 0.34902, 1)], ["scope", "
 
 [sub_resource type="Resource" id="Resource_1h6wi"]
 script = ExtResource("1_barc5")
-name = &"ready_block"
+name = &"ready"
 position = Vector2(54, 47)
 path_child_pairs = []
 block_serialized_properties = SubResource("Resource_b0aen")

--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -170,60 +170,15 @@ static func get_general_blocks() -> Array[Block]:
 	var b: Block
 	var block_list: Array[Block] = []
 
-#region Lifecycle
+	# Lifecycle
+	for block_name in [&"ready", &"process", &"physics_process", &"queue_free"]:
+		b = Util.instantiate_block(block_name)
+		block_list.append(b)
 
-	b = Util.instantiate_block(&"ready")
-	block_list.append(b)
-
-	b = BLOCKS["entry_block"].instantiate()
-	b.block_name = "process_block"
-	b.block_format = "On Process"
-	b.statement = "func _process(delta):"
-	b.tooltip_text = "Attached blocks will be executed during the processing step of the main loop"
-	b.category = "Lifecycle"
-	block_list.append(b)
-
-	b = BLOCKS["entry_block"].instantiate()
-	b.block_name = "physics_process_block"
-	b.block_format = "On Physics Process"
-	b.statement = "func _physics_process(delta):"
-	b.tooltip_text = 'Attached blocks will be executed during the "physics" processing step of the main loop'
-	b.category = "Lifecycle"
-	block_list.append(b)
-
-	b = BLOCKS["statement_block"].instantiate()
-	b.block_name = "queue_free"
-	b.block_format = "Queue Free"
-	b.statement = "queue_free()"
-	b.tooltip_text = "Queues this node to be deleted at the end of the current frame"
-	b.category = "Lifecycle"
-	block_list.append(b)
-
-#endregion
-#region Loops
-
-	b = BLOCKS["control_block"].instantiate()
-	b.block_name = "for_loop"
-	b.block_formats = ["repeat {number: INT}"]
-	b.statements = ["for __i in {number}:"]
-	b.category = "Loops"
-	b.tooltip_text = "Run the connected blocks [i]number[/i] times"
-	block_list.append(b)
-
-	b = BLOCKS["control_block"].instantiate()
-	b.block_name = "while_loop"
-	b.block_formats = ["while {condition: BOOL}"]
-	b.statements = ["while {condition}:"]
-	b.category = "Loops"
-	b.tooltip_text = (
-		"""
-	Run the connected blocks as long as [i]condition[/i] is true.
-
-	Hint: snap a [b]Comparison[/b] block into the condition.
-	"""
-		. dedent()
-	)
-	block_list.append(b)
+	# Loops
+	for block_name in [&"for", &"while", &"break", &"continue"]:
+		b = Util.instantiate_block(block_name)
+		block_list.append(b)
 
 	b = BLOCKS["statement_block"].instantiate()
 	b.block_name = "await_scene_ready"
@@ -238,27 +193,10 @@ static func get_general_blocks() -> Array[Block]:
 	b.category = "Loops"
 	block_list.append(b)
 
-	b = BLOCKS["statement_block"].instantiate()
-	b.block_name = "break"
-	b.block_format = "Break"
-	b.statement = "break"
-	b.category = "Loops"
-	block_list.append(b)
-
-	b = BLOCKS["statement_block"].instantiate()
-	b.block_name = "continue"
-	b.block_format = "Continue"
-	b.statement = "continue"
-	b.category = "Loops"
-	block_list.append(b)
-
-#endregion
-#region Logs
-
+	# Logs
 	b = Util.instantiate_block(&"print")
 	block_list.append(b)
 
-#endregion
 #region Communication
 
 	b = BLOCKS["entry_block"].instantiate()

--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -172,7 +172,7 @@ static func get_general_blocks() -> Array[Block]:
 
 #region Lifecycle
 
-	b = Util.instantiate_block(&"ready_block")
+	b = Util.instantiate_block(&"ready")
 	block_list.append(b)
 
 	b = BLOCKS["entry_block"].instantiate()

--- a/addons/block_code/ui/util.gd
+++ b/addons/block_code/ui/util.gd
@@ -7,6 +7,7 @@ const Types = preload("res://addons/block_code/types/types.gd")
 const SCENE_PER_TYPE = {
 	Types.BlockType.ENTRY: preload("res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"),
 	Types.BlockType.STATEMENT: preload("res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"),
+	Types.BlockType.CONTROL: preload("res://addons/block_code/ui/blocks/control_block/control_block.tscn"),
 }
 
 
@@ -20,8 +21,12 @@ static func instantiate_block(block_name: StringName) -> Block:
 	var scene = SCENE_PER_TYPE[block_definition.type]
 	var b = scene.instantiate()
 	b.block_name = block_definition.name
-	b.block_format = block_definition.display_template
-	b.statement = block_definition.code_template
+	if block_definition.type == Types.BlockType.CONTROL:
+		b.block_formats = [block_definition.display_template]
+		b.statements = [block_definition.code_template]
+	else:
+		b.block_format = block_definition.display_template
+		b.statement = block_definition.code_template
 	b.defaults = block_definition.defaults
 	b.tooltip_text = block_definition.description
 	b.category = block_definition.category

--- a/tests/test_instruction_tree.gd
+++ b/tests/test_instruction_tree.gd
@@ -123,7 +123,7 @@ func test_script_no_entry_blocks():
 
 
 func test_basic_script():
-	var ready_block: Block = dup_node(general_blocks["ready_block"])
+	var ready_block: Block = dup_node(general_blocks[&"ready"])
 
 	var print_block: Block = dup_node(general_blocks["print"])
 	# XXX: It seems like this should substitute {text} in the statement,
@@ -158,8 +158,8 @@ func test_basic_script():
 
 
 func test_multiple_entry_script():
-	var ready_block: Block = dup_node(general_blocks["ready_block"])
-	var print_block: Block = dup_node(general_blocks["print"])
+	var ready_block: Block = dup_node(general_blocks[&"ready"])
+	var print_block: Block = dup_node(general_blocks[&"print"])
 	ready_block.bottom_snap.insert_snapped_block(print_block)
 	ready_block.bottom_snap.snapped_block = print_block
 


### PR DESCRIPTION
Taking as reference commits from #147 

Notable changes:
- The loading occurs in the new block catalog, not in the UI.
- Changed the file matching to use case-insensitive "globbing".
- Sync'ing things like tooltips (description field) that have been updated in main.

https://phabricator.endlessm.com/T35591