### PR TITLE
Add dynamic options lists for blocks

### DIFF
--- a/addons/block_code/block_code_plugin.gd
+++ b/addons/block_code/block_code_plugin.gd
@@ -1,5 +1,6 @@
 @tool
 extends EditorPlugin
+
 const MainPanelScene := preload("res://addons/block_code/ui/main_panel.tscn")
 const MainPanel = preload("res://addons/block_code/ui/main_panel.gd")
 const Types = preload("res://addons/block_code/types/types.gd")
@@ -93,14 +94,8 @@ func _exit_tree():
 
 
 func _ready():
-	connect("scene_changed", _on_scene_changed)
 	editor_inspector.connect("edited_object_changed", _on_editor_inspector_edited_object_changed)
-	_on_scene_changed(EditorInterface.get_edited_scene_root())
 	_on_editor_inspector_edited_object_changed()
-
-
-func _on_scene_changed(scene_root: Node):
-	main_panel.switch_scene(scene_root)
 
 
 func _on_editor_inspector_edited_object_changed():

--- a/addons/block_code/blocks/graphics/animationplayer_play.gd
+++ b/addons/block_code/blocks/graphics/animationplayer_play.gd
@@ -1,0 +1,15 @@
+@tool
+extends BlockExtension
+
+const OptionData = preload("res://addons/block_code/code_generation/option_data.gd")
+
+
+func get_defaults_for_node(context_node: Node) -> Dictionary:
+	var animation_player = context_node as AnimationPlayer
+
+	if not animation_player:
+		return {}
+
+	var animation_list = animation_player.get_animation_list()
+
+	return {"animation": OptionData.new(animation_list)}

--- a/addons/block_code/blocks/graphics/animationplayer_play.tres
+++ b/addons/block_code/blocks/graphics/animationplayer_play.tres
@@ -1,8 +1,13 @@
-[gd_resource type="Resource" load_steps=5 format=3 uid="uid://c5e1byehtxwc0"]
+[gd_resource type="Resource" load_steps=6 format=3 uid="uid://c5e1byehtxwc0"]
 
 [ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_emeuv"]
 [ext_resource type="Script" path="res://addons/block_code/code_generation/option_data.gd" id="1_xu43h"]
 [ext_resource type="Script" path="res://addons/block_code/blocks/graphics/animationplayer_play.gd" id="2_7ymgi"]
+
+[sub_resource type="Resource" id="Resource_qpxn2"]
+script = ExtResource("1_xu43h")
+selected = 0
+items = []
 
 [sub_resource type="Resource" id="Resource_vnp2w"]
 script = ExtResource("1_xu43h")
@@ -17,13 +22,14 @@ description = "Play the animation."
 category = "Graphics | Animation"
 type = 2
 variant_type = 0
-display_template = "Play {animation: OPTION} {direction: OPTION}"
-code_template = "if \"{direction}\" == \"ahead\":
-	play(\"{animation}\")
+display_template = "Play {animation: STRING} {direction: NIL}"
+code_template = "if {direction} == \"ahead\":
+	play({animation})
 else:
-	play_backwards(\"{animation}\")
+	play_backwards({animation})
 "
 defaults = {
+"animation": SubResource("Resource_qpxn2"),
 "direction": SubResource("Resource_vnp2w")
 }
 signal_name = ""

--- a/addons/block_code/blocks/graphics/animationplayer_play.tres
+++ b/addons/block_code/blocks/graphics/animationplayer_play.tres
@@ -1,7 +1,8 @@
-[gd_resource type="Resource" load_steps=4 format=3 uid="uid://c5e1byehtxwc0"]
+[gd_resource type="Resource" load_steps=5 format=3 uid="uid://c5e1byehtxwc0"]
 
 [ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_emeuv"]
 [ext_resource type="Script" path="res://addons/block_code/code_generation/option_data.gd" id="1_xu43h"]
+[ext_resource type="Script" path="res://addons/block_code/blocks/graphics/animationplayer_play.gd" id="2_7ymgi"]
 
 [sub_resource type="Resource" id="Resource_vnp2w"]
 script = ExtResource("1_xu43h")
@@ -16,14 +17,15 @@ description = "Play the animation."
 category = "Graphics | Animation"
 type = 2
 variant_type = 0
-display_template = "Play {animation: STRING} {direction: OPTION}"
+display_template = "Play {animation: OPTION} {direction: OPTION}"
 code_template = "if \"{direction}\" == \"ahead\":
-	play({animation})
+	play(\"{animation}\")
 else:
-	play_backwards({animation})
+	play_backwards(\"{animation}\")
 "
 defaults = {
 "direction": SubResource("Resource_vnp2w")
 }
 signal_name = ""
 scope = ""
+extension_script = ExtResource("2_7ymgi")

--- a/addons/block_code/blocks/logic/compare.tres
+++ b/addons/block_code/blocks/logic/compare.tres
@@ -16,8 +16,8 @@ description = ""
 category = "Logic | Comparison"
 type = 3
 variant_type = 1
-display_template = "{float1: FLOAT} {op: OPTION} {float2: FLOAT}"
-code_template = "{float1} {op} {float2}"
+display_template = "{float1: FLOAT} {op: NIL} {float2: FLOAT}"
+code_template = "{float1} {{op}} {float2}"
 defaults = {
 "float1": 1.0,
 "float2": 1.0,

--- a/addons/block_code/blocks/sounds/pause_continue_sound.tres
+++ b/addons/block_code/blocks/sounds/pause_continue_sound.tres
@@ -6,7 +6,7 @@
 [sub_resource type="Resource" id="Resource_lalgp"]
 script = ExtResource("1_ilhdq")
 selected = 0
-items = ["Pause", "Continue"]
+items = ["pause", "continue"]
 
 [resource]
 script = ExtResource("1_q04gm")
@@ -16,9 +16,9 @@ description = "Pause/Continue the audio stream"
 category = "Sounds"
 type = 2
 variant_type = 0
-display_template = "{pause: OPTION} the sound {name: STRING}"
+display_template = "{pause: NIL} the sound {name: STRING}"
 code_template = "var __sound_node = get_node({name})
-if \"{pause}\" == \"pause\":
+if {pause} == \"pause\":
 	__sound_node.stream_paused = true
 else:
 	__sound_node.stream_paused = false

--- a/addons/block_code/code_generation/block_ast.gd
+++ b/addons/block_code/code_generation/block_ast.gd
@@ -55,11 +55,15 @@ class ASTNode:
 			# Use parentheses to be safe
 			var argument = arguments[arg_name]
 			var code_string: String
+			var raw_string: String
 			if argument is ASTValueNode:
 				code_string = argument.get_code()
+				raw_string = code_string
 			else:
 				code_string = BlockAST.raw_input_to_code_string(argument)
+				raw_string = str(argument)
 
+			code_block = code_block.replace("{{%s}}" % arg_name, raw_string)
 			code_block = code_block.replace("{%s}" % arg_name, code_string)
 
 		return IDHandler.make_unique(code_block)
@@ -99,11 +103,15 @@ class ASTValueNode:
 			# Use parentheses to be safe
 			var argument = arguments[arg_name]
 			var code_string: String
+			var raw_string: String
 			if argument is ASTValueNode:
 				code_string = argument.get_code()
+				raw_string = code_string
 			else:
 				code_string = BlockAST.raw_input_to_code_string(argument)
+				raw_string = str(argument)
 
+			code = code.replace("{{%s}}" % arg_name, raw_string)
 			code = code.replace("{%s}" % arg_name, code_string)
 
 		return IDHandler.make_unique("(%s)" % code)
@@ -130,15 +138,11 @@ func to_string_recursive(node: ASTNode, depth: int) -> String:
 static func raw_input_to_code_string(input) -> String:
 	match typeof(input):
 		TYPE_STRING:
-			return "'%s'" % input.replace("\\", "\\\\").replace("'", "\\'")
+			return "'%s'" % input.c_escape()
 		TYPE_VECTOR2:
 			return "Vector2%s" % str(input)
 		TYPE_COLOR:
 			return "Color%s" % str(input)
-		TYPE_OBJECT:
-			if input is OptionData:
-				var option_data := input as OptionData
-				return option_data.items[option_data.selected]
 		_:
 			return "%s" % input
 

--- a/addons/block_code/code_generation/block_ast.gd
+++ b/addons/block_code/code_generation/block_ast.gd
@@ -104,6 +104,14 @@ static func format_code_template(code_template: String, arguments: Dictionary) -
 		var code_string: String
 		var raw_string: String
 
+		if argument_value is OptionData:
+			# Temporary hack: previously, the value was stored as an OptionData
+			# object with a list of items and a "selected" property. If we are
+			# using an older block script where that is the case, convert the
+			# value to the value of its selected item.
+			# See also, ParameterInput._update_option_input.
+			argument_value = argument_value.items[argument_value.selected]
+
 		if argument_value is ASTValueNode:
 			code_string = argument_value.get_code()
 			raw_string = code_string

--- a/addons/block_code/code_generation/block_definition.gd
+++ b/addons/block_code/code_generation/block_definition.gd
@@ -4,6 +4,8 @@ extends Resource
 
 const Types = preload("res://addons/block_code/types/types.gd")
 
+const FORMAT_STRING_PATTERN = "\\[(?<out_parameter>[^\\]]+)\\]|\\{(?<in_parameter>[^}]+)\\}|(?<label>[^\\{\\[]+)"
+
 @export var name: StringName
 
 ## The target node. Leaving this empty the block is considered a general block
@@ -28,6 +30,8 @@ const Types = preload("res://addons/block_code/types/types.gd")
 @export var scope: String
 
 @export var extension_script: GDScript
+
+static var _display_template_regex := RegEx.create_from_string(FORMAT_STRING_PATTERN)
 
 var _extension: BlockExtension:
 	get:
@@ -76,3 +80,52 @@ func get_defaults_for_node(parent_node: Node) -> Dictionary:
 
 func _to_string():
 	return "%s - %s" % [name, target_node_class]
+
+
+func get_output_parameters() -> Dictionary:
+	var result: Dictionary
+	for item in parse_display_template(display_template):
+		if item.has("out_parameter"):
+			var parameter = item.get("out_parameter")
+			result[parameter["name"]] = parameter["type"]
+	return result
+
+
+static func parse_display_template(template_string: String):
+	var items: Array[Dictionary]
+	for regex_match in _display_template_regex.search_all(template_string):
+		if regex_match.names.has("label"):
+			var label_string := regex_match.get_string("label")
+			items.append({"label": label_string})
+		elif regex_match.names.has("in_parameter"):
+			var parameter_string := regex_match.get_string("in_parameter")
+			items.append({"in_parameter": _parse_parameter_format(parameter_string)})
+		elif regex_match.names.has("out_parameter"):
+			var parameter_string := regex_match.get_string("out_parameter")
+			items.append({"out_parameter": _parse_parameter_format(parameter_string)})
+	return items
+
+
+static func _parse_parameter_format(parameter_format: String) -> Dictionary:
+	var parameter_name: String
+	var parameter_type_str: String
+	var parameter_type: Variant.Type
+	var split := parameter_format.split(":", true, 1)
+
+	if len(split) == 0:
+		return {}
+
+	if len(split) > 0:
+		parameter_name = split[0].strip_edges()
+
+	if len(split) > 1:
+		parameter_type_str = split[1].strip_edges()
+
+	if parameter_type_str:
+		parameter_type = Types.STRING_TO_VARIANT_TYPE[parameter_type_str]
+
+	return {"name": parameter_name, "type": parameter_type}
+
+
+static func has_category(block_definition, category: String) -> bool:
+	return block_definition.category == category

--- a/addons/block_code/code_generation/block_definition.gd
+++ b/addons/block_code/code_generation/block_definition.gd
@@ -64,5 +64,15 @@ func _init(
 	extension_script = p_extension_script
 
 
+func get_defaults_for_node(parent_node: Node) -> Dictionary:
+	if not _extension:
+		return defaults
+
+	# Use Dictionary.merge instead of Dictionary.merged for Godot 4.2 compatibility
+	var new_defaults := _extension.get_defaults_for_node(parent_node)
+	new_defaults.merge(defaults)
+	return new_defaults
+
+
 func _to_string():
 	return "%s - %s" % [name, target_node_class]

--- a/addons/block_code/code_generation/block_definition.gd
+++ b/addons/block_code/code_generation/block_definition.gd
@@ -27,6 +27,14 @@ const Types = preload("res://addons/block_code/types/types.gd")
 ## Empty except for blocks that have a defined scope
 @export var scope: String
 
+@export var extension_script: GDScript
+
+var _extension: BlockExtension:
+	get:
+		if _extension == null and extension_script and extension_script.can_instantiate():
+			_extension = extension_script.new()
+		return _extension as BlockExtension
+
 
 func _init(
 	p_name: StringName = &"",
@@ -40,6 +48,7 @@ func _init(
 	p_defaults = {},
 	p_signal_name: String = "",
 	p_scope: String = "",
+	p_extension_script: GDScript = null,
 ):
 	name = p_name
 	target_node_class = p_target_node_class
@@ -52,6 +61,7 @@ func _init(
 	defaults = p_defaults
 	signal_name = p_signal_name
 	scope = p_scope
+	extension_script = p_extension_script
 
 
 func _to_string():

--- a/addons/block_code/code_generation/block_extension.gd
+++ b/addons/block_code/code_generation/block_extension.gd
@@ -1,3 +1,7 @@
 @tool
 class_name BlockExtension
 extends Object
+
+
+func get_defaults_for_node(context_node: Node) -> Dictionary:
+	return {}

--- a/addons/block_code/code_generation/block_extension.gd
+++ b/addons/block_code/code_generation/block_extension.gd
@@ -1,0 +1,3 @@
+@tool
+class_name BlockExtension
+extends Object

--- a/addons/block_code/code_generation/blocks_catalog.gd
+++ b/addons/block_code/code_generation/blocks_catalog.gd
@@ -96,40 +96,6 @@ static func _setup_definitions_from_files():
 		_by_class_name[target][block_definition.name] = block_definition
 
 
-static func _add_output_definitions(definitions: Array[BlockDefinition]):
-	# Capture things of format [test]
-	var _output_regex := RegEx.create_from_string("\\[([^\\]]+)\\]")
-
-	for definition in definitions:
-		if definition.type != Types.BlockType.ENTRY:
-			continue
-
-		for reg_match in _output_regex.search_all(definition.display_template):
-			var parts := reg_match.get_string(1).split(": ")
-			var param_name := parts[0]
-			var param_type: Variant.Type = Types.STRING_TO_VARIANT_TYPE[parts[1]]
-
-			var output_def := BlockDefinition.new()
-			output_def.name = &"%s_%s" % [definition.name, param_name]
-			output_def.target_node_class = definition.target_node_class
-			output_def.category = definition.category
-			output_def.type = Types.BlockType.VALUE
-			output_def.variant_type = param_type
-			output_def.display_template = param_name
-			output_def.code_template = param_name
-			output_def.scope = definition.code_template
-
-			# Note that these are not added to the _by_class_name dict
-			# because they only make sense within the entry block scope.
-			_catalog[output_def.name] = output_def
-
-
-static func _setup_output_definitions():
-	var definitions: Array[BlockDefinition]
-	definitions.assign(_catalog.values())
-	_add_output_definitions(definitions)
-
-
 static func _add_property_definitions(_class_name: String, property_list: Array[Dictionary], property_settings: Dictionary):
 	for property in property_list:
 		if not property.name in property_settings:
@@ -256,7 +222,6 @@ static func setup():
 
 	_catalog = {}
 	_setup_definitions_from_files()
-	_setup_output_definitions()
 	_setup_properties_for_class()
 	_setup_input_block()
 
@@ -330,7 +295,6 @@ static func add_custom_blocks(
 		_catalog[block_definition.name] = block_definition
 		_by_class_name[_class_name][block_definition.name] = block_definition
 
-	_add_output_definitions(block_definitions)
 	_add_property_definitions(_class_name, property_list, property_settings)
 
 

--- a/addons/block_code/code_generation/blocks_catalog.gd
+++ b/addons/block_code/code_generation/blocks_catalog.gd
@@ -198,8 +198,8 @@ static func _setup_input_block():
 			"Input",
 			Types.BlockType.VALUE,
 			TYPE_BOOL,
-			"Is action {action_name: OPTION} {action: OPTION}",
-			'Input.is_action_{action}("{action_name}")',
+			"Is action {action_name: STRING_NAME} {action: NIL}",
+			"Input.is_action_{{action}}('{{action_name}}')",
 			{"action_name": OptionData.new(inputmap_actions), "action": OptionData.new(["pressed", "just_pressed", "just_released"])},
 		)
 	)

--- a/addons/block_code/code_generation/blocks_catalog.gd
+++ b/addons/block_code/code_generation/blocks_catalog.gd
@@ -224,14 +224,9 @@ static func has_block(block_name: StringName):
 	return block_name in _catalog
 
 
-static func get_blocks_by_class(_class_name: String) -> Array[BlockDefinition]:
+static func _get_blocks_by_class(_class_name: String) -> Array[BlockDefinition]:
 	var result: Array[BlockDefinition]
-
-	if not _class_name:
-		return result
-
 	result.assign(_catalog.values().filter(_block_definition_has_class_name.bind(_class_name)))
-
 	return result
 
 
@@ -263,7 +258,9 @@ static func _get_custom_parent_class_name(_custom_class_name: String) -> String:
 static func _get_parents(_class_name: String) -> Array[String]:
 	if ClassDB.class_exists(_class_name):
 		return _get_builtin_parents(_class_name)
-	var parents: Array[String] = [_class_name]
+	var parents: Array[String] = []
+	if _class_name != "":
+		parents.append(_class_name)
 	var _parent_class_name = _get_custom_parent_class_name(_class_name)
 	parents.append_array(_get_builtin_parents(_parent_class_name))
 	return parents
@@ -274,7 +271,8 @@ static func get_inherited_blocks(_class_name: String) -> Array[BlockDefinition]:
 
 	var definitions: Array[BlockDefinition] = []
 	for _parent_class_name in _get_parents(_class_name):
-		definitions.append_array(get_blocks_by_class(_parent_class_name))
+		definitions.append_array(_get_blocks_by_class(_parent_class_name))
+	definitions.append_array(_get_blocks_by_class(""))
 	return definitions
 
 

--- a/addons/block_code/drag_manager/drag_manager.gd
+++ b/addons/block_code/drag_manager/drag_manager.gd
@@ -15,6 +15,8 @@ const Util = preload("res://addons/block_code/ui/util.gd")
 
 const Constants = preload("res://addons/block_code/ui/constants.gd")
 
+@onready var _context := BlockEditorContext.get_default()
+
 var _picker: Picker
 var _block_canvas: BlockCanvas
 
@@ -64,9 +66,9 @@ func drag_block(block: Block, copied_from: Block = null):
 
 
 func copy_block(block: Block) -> Block:
-	var new_block = Util.instantiate_block(block.definition)
-	new_block.color = block.color
-	return new_block
+	if _context.block_script == null:
+		return null
+	return _context.block_script.instantiate_block(block.definition)
 
 
 func copy_picked_block_and_drag(block: Block):

--- a/addons/block_code/serialization/block_script_serialization.gd
+++ b/addons/block_code/serialization/block_script_serialization.gd
@@ -135,7 +135,6 @@ func _get_parameter_block_definition(block_name: String, parameter_name: String)
 
 func _update_block_definitions():
 	_available_blocks.clear()
-	_available_blocks.append_array(_get_default_block_definitions())
 	_available_blocks.append_array(_get_inherited_block_definitions())
 	_available_blocks.append_array(_get_variable_block_definitions())
 
@@ -174,64 +173,6 @@ func load_object_script() -> Object:
 		if class_dict.class == script_inherits:
 			return load(class_dict.path) as Object
 	return null
-
-
-func _get_default_block_definitions() -> Array[BlockDefinition]:
-	var block: BlockDefinition
-	var block_list: Array[BlockDefinition] = []
-
-	# Lifecycle
-	for block_name in [&"ready", &"process", &"physics_process", &"queue_free"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	# Loops
-	for block_name in [&"for", &"while", &"break", &"continue", &"await_scene_ready"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	# Logs
-	block = BlocksCatalog.get_block(&"print")
-	block_list.append(block)
-
-	# Communication
-	for block_name in [&"define_method", &"call_method_group", &"call_method_node"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	for block_name in [&"add_to_group", &"add_node_to_group", &"remove_from_group", &"remove_node_from_group", &"is_in_group", &"is_node_in_group"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	# Variables
-	block = BlocksCatalog.get_block(&"vector2")
-	block_list.append(block)
-
-	# Math
-	for block_name in [&"add", &"subtract", &"multiply", &"divide", &"pow", &"randf_range", &"randi_range", &"sin", &"cos", &"tan"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	# Logic
-	for block_name in [&"if", &"else_if", &"else", &"compare", &"and", &"or", &"not"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	# Input
-	block = BlocksCatalog.get_block(&"is_input_actioned")
-	block_list.append(block)
-
-	# Sounds
-	for block_name in [&"load_sound", &"play_sound", &"pause_continue_sound", &"stop_sound"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	# Graphics
-	for block_name in [&"viewport_width", &"viewport_height", &"viewport_center"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	return block_list
 
 
 func _get_inherited_block_definitions() -> Array[BlockDefinition]:

--- a/addons/block_code/serialization/block_script_serialization.gd
+++ b/addons/block_code/serialization/block_script_serialization.gd
@@ -4,13 +4,22 @@ extends Resource
 
 const ASTList = preload("res://addons/block_code/code_generation/ast_list.gd")
 const BlockAST = preload("res://addons/block_code/code_generation/block_ast.gd")
-const BlocksCatalog = preload("res://addons/block_code/code_generation/blocks_catalog.gd")
 const BlockCategory = preload("res://addons/block_code/ui/picker/categories/block_category.gd")
 const BlockDefinition = preload("res://addons/block_code/code_generation/block_definition.gd")
 const BlockSerialization = preload("res://addons/block_code/serialization/block_serialization.gd")
 const BlockSerializationTree = preload("res://addons/block_code/serialization/block_serialization_tree.gd")
+const BlocksCatalog = preload("res://addons/block_code/code_generation/blocks_catalog.gd")
+const CategoryFactory = preload("res://addons/block_code/ui/picker/categories/category_factory.gd")
+const Types = preload("res://addons/block_code/types/types.gd")
 const ValueBlockSerialization = preload("res://addons/block_code/serialization/value_block_serialization.gd")
 const VariableDefinition = preload("res://addons/block_code/code_generation/variable_definition.gd")
+
+const SCENE_PER_TYPE = {
+	Types.BlockType.ENTRY: preload("res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"),
+	Types.BlockType.STATEMENT: preload("res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"),
+	Types.BlockType.VALUE: preload("res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"),
+	Types.BlockType.CONTROL: preload("res://addons/block_code/ui/blocks/control_block/control_block.tscn"),
+}
 
 @export var script_inherits: String
 @export var block_serialization_trees: Array[BlockSerializationTree]
@@ -19,7 +28,8 @@ const VariableDefinition = preload("res://addons/block_code/code_generation/vari
 @export var generated_script: String
 @export var version: int
 
-var _var_block_definitions: Dictionary  # String, BlockDefinition
+var _available_blocks: Array[BlockDefinition]
+var _categories: Array[BlockCategory]
 
 
 func _init(
@@ -32,36 +42,108 @@ func _init(
 	version = p_version
 
 
+func initialize():
+	_update_block_definitions()
+
+
 func _set_variables(value):
 	variables = value
-	_refresh_var_block_definitions()
+	_update_block_definitions()
 
 
-func _refresh_var_block_definitions():
-	_var_block_definitions.clear()
-	for block_def in BlocksCatalog.get_variable_block_definitions(variables):
-		_var_block_definitions[block_def.name] = block_def
+func instantiate_block(block_definition: BlockDefinition) -> Block:
+	if block_definition == null:
+		push_error("Cannot construct block from null block definition.")
+		return null
+
+	var scene := SCENE_PER_TYPE.get(block_definition.type)
+	if scene == null:
+		push_error("Cannot instantiate Block from type %s" % block_definition.type)
+		return null
+
+	var block_category := _get_category_by_name(block_definition.category)
+
+	var block: Block = scene.instantiate()
+	block.definition = block_definition
+	block.color = block_category.color if block_category else Color.WHITE
+	return block
 
 
-func _get_block(block_name: StringName) -> BlockDefinition:
-	var block_def: BlockDefinition = _var_block_definitions.get(block_name)
-	if block_def == null:
-		block_def = BlocksCatalog.get_block(block_name)
-	return block_def
+func instantiate_block_by_name(block_name: String) -> Block:
+	var block_definition := get_block_definition(block_name)
+
+	if block_definition == null:
+		push_warning("Cannot find a block definition for %s" % block_name)
+		return null
+
+	return instantiate_block(block_definition)
 
 
-func get_definitions() -> Array[BlockDefinition]:
-	for class_dict in ProjectSettings.get_global_class_list():
-		if class_dict.class == script_inherits:
-			var script = load(class_dict.path)
-			if script.has_method("setup_custom_blocks"):
-				script.setup_custom_blocks()
-			break
+func get_block_definition(block_name: String) -> BlockDefinition:
+	var split := block_name.split(":", true, 1)
 
-	return BlocksCatalog.get_inherited_blocks(script_inherits)
+	if len(split) > 1:
+		return _get_parameter_block_definition(split[0], split[1])
+
+	var block_definition = _get_base_block_definition(block_name)
+
+	if block_definition == null:
+		# FIXME: This is a workaround for old-style output block references.
+		#        These were generated ahead of time using a block name that has
+		#        a "_" before the parameter name. Now, these parameter blocks
+		#        are generated on demand for any block name containing a ":".
+		#        Please remove this fallback when it is no longer necessary.
+		split = block_name.rsplit("_", true, 1)
+		return _get_parameter_block_definition(split[0], split[1])
+
+	return block_definition
 
 
-func get_categories() -> Array[BlockCategory]:
+func _get_base_block_definition(block_name: String) -> BlockDefinition:
+	for block_definition in _available_blocks:
+		if block_definition.name == block_name:
+			return block_definition
+	return null
+
+
+func _get_parameter_block_definition(block_name: String, parameter_name: String) -> BlockDefinition:
+	var base_block_definition := _get_base_block_definition(block_name)
+
+	if base_block_definition == null:
+		return null
+
+	var parent_out_parameters = base_block_definition.get_output_parameters()
+
+	if not parent_out_parameters.has(parameter_name):
+		push_error("The parameter name %s is not an output parameter in %s." % [parameter_name, block_name])
+		return null
+
+	var parameter_type: Variant.Type = parent_out_parameters[parameter_name]
+
+	var block_definition := BlockDefinition.new()
+	block_definition.name = &"%s:%s" % [block_name, parameter_name]
+	block_definition.target_node_class = base_block_definition.target_node_class
+	block_definition.category = base_block_definition.category
+	block_definition.type = Types.BlockType.VALUE
+	block_definition.variant_type = parameter_type
+	block_definition.display_template = parameter_name
+	block_definition.code_template = parameter_name
+	block_definition.scope = base_block_definition.code_template
+
+	return block_definition
+
+
+func _update_block_definitions():
+	_available_blocks.clear()
+	_available_blocks.append_array(_get_default_block_definitions())
+	_available_blocks.append_array(_get_inherited_block_definitions())
+	_available_blocks.append_array(_get_variable_block_definitions())
+
+	var custom_categories: Array[BlockCategory] = _get_custom_categories()
+	_categories = CategoryFactory.get_all_categories(custom_categories)
+
+
+func _get_custom_categories() -> Array[BlockCategory]:
 	for class_dict in ProjectSettings.get_global_class_list():
 		if class_dict.class == script_inherits:
 			var script = load(class_dict.path)
@@ -69,6 +151,95 @@ func get_categories() -> Array[BlockCategory]:
 				return script.get_custom_categories()
 
 	return []
+
+
+func get_available_blocks() -> Array[BlockDefinition]:
+	return _available_blocks
+
+
+func get_available_categories() -> Array[BlockCategory]:
+	return _categories.filter(func(category): return _available_blocks.any(BlockDefinition.has_category.bind(category.name)))
+
+
+func get_blocks_in_category(category: BlockCategory) -> Array[BlockDefinition]:
+	return _available_blocks.filter(BlockDefinition.has_category.bind(category.name))
+
+
+func _get_category_by_name(category_name: String) -> BlockCategory:
+	return _categories.filter(func(category): return category.name == category_name).front()
+
+
+func load_object_script() -> Object:
+	for class_dict in ProjectSettings.get_global_class_list():
+		if class_dict.class == script_inherits:
+			return load(class_dict.path) as Object
+	return null
+
+
+func _get_default_block_definitions() -> Array[BlockDefinition]:
+	var block: BlockDefinition
+	var block_list: Array[BlockDefinition] = []
+
+	# Lifecycle
+	for block_name in [&"ready", &"process", &"physics_process", &"queue_free"]:
+		block = BlocksCatalog.get_block(block_name)
+		block_list.append(block)
+
+	# Loops
+	for block_name in [&"for", &"while", &"break", &"continue", &"await_scene_ready"]:
+		block = BlocksCatalog.get_block(block_name)
+		block_list.append(block)
+
+	# Logs
+	block = BlocksCatalog.get_block(&"print")
+	block_list.append(block)
+
+	# Communication
+	for block_name in [&"define_method", &"call_method_group", &"call_method_node"]:
+		block = BlocksCatalog.get_block(block_name)
+		block_list.append(block)
+
+	for block_name in [&"add_to_group", &"add_node_to_group", &"remove_from_group", &"remove_node_from_group", &"is_in_group", &"is_node_in_group"]:
+		block = BlocksCatalog.get_block(block_name)
+		block_list.append(block)
+
+	# Variables
+	block = BlocksCatalog.get_block(&"vector2")
+	block_list.append(block)
+
+	# Math
+	for block_name in [&"add", &"subtract", &"multiply", &"divide", &"pow", &"randf_range", &"randi_range", &"sin", &"cos", &"tan"]:
+		block = BlocksCatalog.get_block(block_name)
+		block_list.append(block)
+
+	# Logic
+	for block_name in [&"if", &"else_if", &"else", &"compare", &"and", &"or", &"not"]:
+		block = BlocksCatalog.get_block(block_name)
+		block_list.append(block)
+
+	# Input
+	block = BlocksCatalog.get_block(&"is_input_actioned")
+	block_list.append(block)
+
+	# Sounds
+	for block_name in [&"load_sound", &"play_sound", &"pause_continue_sound", &"stop_sound"]:
+		block = BlocksCatalog.get_block(block_name)
+		block_list.append(block)
+
+	# Graphics
+	for block_name in [&"viewport_width", &"viewport_height", &"viewport_center"]:
+		block = BlocksCatalog.get_block(block_name)
+		block_list.append(block)
+
+	return block_list
+
+
+func _get_inherited_block_definitions() -> Array[BlockDefinition]:
+	return BlocksCatalog.get_inherited_blocks(script_inherits)
+
+
+func _get_variable_block_definitions() -> Array[BlockDefinition]:
+	return BlocksCatalog.get_variable_block_definitions(variables)
 
 
 func generate_ast_list() -> ASTList:
@@ -87,7 +258,7 @@ func _tree_to_ast(tree: BlockSerializationTree) -> BlockAST:
 
 func _block_to_ast_node(node: BlockSerialization) -> BlockAST.ASTNode:
 	var ast_node := BlockAST.ASTNode.new()
-	ast_node.data = _get_block(node.name)
+	ast_node.data = get_block_definition(node.name)
 
 	for arg_name in node.arguments:
 		var argument = node.arguments[arg_name]
@@ -105,7 +276,7 @@ func _block_to_ast_node(node: BlockSerialization) -> BlockAST.ASTNode:
 
 func _value_to_ast_value(value_node: ValueBlockSerialization) -> BlockAST.ASTValueNode:
 	var ast_value_node := BlockAST.ASTValueNode.new()
-	ast_value_node.data = _get_block(value_node.name)
+	ast_value_node.data = get_block_definition(value_node.name)
 
 	for arg_name in value_node.arguments:
 		var argument = value_node.arguments[arg_name]

--- a/addons/block_code/simple_nodes/simple_character/simple_character.gd
+++ b/addons/block_code/simple_nodes/simple_character/simple_character.gd
@@ -133,7 +133,7 @@ static func setup_custom_blocks():
 	block_definition.target_node_class = _class_name
 	block_definition.category = "Input"
 	block_definition.type = Types.BlockType.STATEMENT
-	block_definition.display_template = "Move with {player: OPTION} buttons as {kind: OPTION}"
+	block_definition.display_template = "Move with {player: NIL} buttons as {kind: NIL}"
 	block_definition.description = """Move the character using the “Player 1” or “Player 2” controls as configured in Godot.
 
 “Top-down” enables the character to move in both x (vertical) and y (horizontal) dimensions, as if the camera is above the character, looking down. No gravity is added.
@@ -143,7 +143,7 @@ static func setup_custom_blocks():
 “Spaceship” uses the left/right controls to turn the character and up/down controls to go forward or backward."""
 	# TODO: delta here is assumed to be the parameter name of
 	# the _process or _physics_process method:
-	block_definition.code_template = 'move_with_player_buttons("{player}", "{kind}", delta)'
+	block_definition.code_template = "move_with_player_buttons({player}, {kind}, delta)"
 	block_definition.defaults = {
 		"player": OptionData.new(["player_1", "player_2"]),
 		"kind": OptionData.new(["top-down", "platformer", "spaceship"]),

--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -15,6 +15,8 @@ const DEFAULT_WINDOW_MARGIN: Vector2 = Vector2(25, 25)
 const SNAP_GRID: Vector2 = Vector2(25, 25)
 const ZOOM_FACTOR: float = 1.1
 
+@onready var _context := BlockEditorContext.get_default()
+
 @onready var _window: Control = %Window
 @onready var _empty_box: BoxContainer = %EmptyBox
 
@@ -52,6 +54,8 @@ signal replace_block_code
 
 
 func _ready():
+	_context.changed.connect(_on_context_changed)
+
 	if not _open_scene_button.icon and not Util.node_is_part_of_edited_scene(self):
 		_open_scene_button.icon = _open_scene_icon
 
@@ -87,12 +91,12 @@ func set_child(n: Node):
 		set_child(c)
 
 
-func block_script_selected(block_script: BlockScriptSerialization):
+func _on_context_changed():
 	clear_canvas()
 
 	var edited_node = EditorInterface.get_inspector().get_edited_object() as Node
 
-	if block_script != _current_block_script:
+	if _context.block_script != _current_block_script:
 		_window.position = Vector2(0, 0)
 		zoom = 1
 
@@ -106,12 +110,12 @@ func block_script_selected(block_script: BlockScriptSerialization):
 	_open_scene_button.disabled = true
 	_replace_block_code_button.disabled = true
 
-	if block_script != null:
-		_load_block_script(block_script)
+	if _context.block_script != null:
+		_load_block_script(_context.block_script)
 		_window.visible = true
 		_zoom_button.visible = true
 
-		if block_script != _current_block_script:
+		if _context.block_script != _current_block_script:
 			reset_window_position()
 	elif edited_node == null:
 		_empty_box.visible = true
@@ -130,7 +134,7 @@ func block_script_selected(block_script: BlockScriptSerialization):
 		_selected_node_label.text = _selected_node_label_format.format({"node": edited_node.name})
 		_add_block_code_button.disabled = false
 
-	_current_block_script = block_script
+	_current_block_script = _context.block_script
 
 
 func _load_block_script(block_script: BlockScriptSerialization):
@@ -146,8 +150,8 @@ func reload_ui_from_ast_list():
 
 
 func ui_tree_from_ast_node(ast_node: BlockAST.ASTNode) -> Block:
-	var block: Block = Util.instantiate_block(ast_node.data)
-	block.color = Util.get_category_color(ast_node.data.category)
+	var block: Block = _context.block_script.instantiate_block(ast_node.data)
+
 	# Args
 	for arg_name in ast_node.arguments:
 		var argument = ast_node.arguments[arg_name]
@@ -177,8 +181,8 @@ func ui_tree_from_ast_node(ast_node: BlockAST.ASTNode) -> Block:
 
 
 func ui_tree_from_ast_value_node(ast_value_node: BlockAST.ASTValueNode) -> Block:
-	var block: Block = Util.instantiate_block(ast_value_node.data)
-	block.color = Util.get_category_color(ast_value_node.data.category)
+	var block: Block = _context.block_script.instantiate_block(ast_value_node.data)
+
 	# Args
 	for arg_name in ast_value_node.arguments:
 		var argument = ast_value_node.arguments[arg_name]
@@ -259,7 +263,7 @@ func build_value_ast(block: ParameterBlock) -> BlockAST.ASTValueNode:
 
 
 func rebuild_block_serialization_trees():
-	_current_block_script.update_from_ast_list(_current_ast_list)
+	_context.block_script.update_from_ast_list(_current_ast_list)
 
 
 func find_snaps(node: Node) -> Array[SnapPoint]:
@@ -383,7 +387,7 @@ func set_mouse_override(override: bool):
 
 
 func generate_script_from_current_window() -> String:
-	return ScriptGenerator.generate_script(_current_ast_list, _current_block_script)
+	return ScriptGenerator.generate_script(_current_ast_list, _context.block_script)
 
 
 func _on_zoom_button_pressed():

--- a/addons/block_code/ui/block_editor_context.gd
+++ b/addons/block_code/ui/block_editor_context.gd
@@ -1,0 +1,33 @@
+class_name BlockEditorContext
+extends Object
+
+signal changed
+
+static var _instance: BlockEditorContext
+
+var block_code_node: BlockCode:
+	set(value):
+		block_code_node = value
+		changed.emit()
+
+var block_script: BlockScriptSerialization:
+	get:
+		if block_code_node == null:
+			return null
+		return block_code_node.block_script
+
+var parent_node: Node:
+	get:
+		if block_code_node == null:
+			return null
+		return block_code_node.get_parent()
+
+
+func force_update() -> void:
+	changed.emit()
+
+
+static func get_default() -> BlockEditorContext:
+	if _instance == null:
+		_instance = BlockEditorContext.new()
+	return _instance

--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -60,6 +60,12 @@ func _update_template_editor():
 
 	template_editor.format_string = definition.display_template if definition else ""
 	template_editor.parameter_defaults = definition.get_defaults_for_node(_context.parent_node) if definition else {}
+	if not template_editor.modified.is_connected(_on_template_editor_modified):
+		template_editor.modified.connect(_on_template_editor_modified)
+
+
+func _on_template_editor_modified():
+	modified.emit()
 
 
 func _gui_input(event):
@@ -82,10 +88,6 @@ func _gui_input(event):
 				dialog.dialog_text = "Delete block?"
 			dialog.confirmed.connect(remove_from_tree)
 			EditorInterface.popup_dialog_centered(dialog)
-
-
-func _modified():
-	modified.emit()
 
 
 func remove_from_tree():

--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -10,9 +10,6 @@ signal modified
 ## Color of block (optionally used to draw block color)
 @export var color: Color = Color(1., 1., 1.)
 
-## Category to add the block to
-@export var category: String
-
 # FIXME Note: This used to be a NodePath. There is a bug in Godot 4.2 that causes the
 # reference to not be set properly when the node is duplicated. Since we don't
 # use the Node duplicate function anymore, this is okay.

--- a/addons/block_code/ui/blocks/control_block/control_block.gd
+++ b/addons/block_code/ui/blocks/control_block/control_block.gd
@@ -3,9 +3,9 @@ class_name ControlBlock
 extends Block
 
 const Constants = preload("res://addons/block_code/ui/constants.gd")
-
-var arg_name_to_param_input_dict: Dictionary
-var args_to_add_after_format: Dictionary  # Only used when loading
+const DragDropArea = preload("res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.gd")
+const DragDropAreaScene = preload("res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn")
+const Gutter = preload("res://addons/block_code/ui/blocks/utilities/background/gutter.gd")
 
 
 func _ready():
@@ -19,16 +19,6 @@ func _ready():
 	%SnapGutter.color = color
 	%SnapGutter.custom_minimum_size.x = Constants.CONTROL_MARGIN
 
-	format()
-
-	for arg_name in arg_name_to_param_input_dict:
-		if arg_name in args_to_add_after_format:
-			var argument = args_to_add_after_format[arg_name]
-			if argument is Block:
-				arg_name_to_param_input_dict[arg_name].snap_point.add_child(argument)
-			else:
-				arg_name_to_param_input_dict[arg_name].set_raw_input(argument)
-
 
 func _on_drag_drop_area_mouse_down():
 	_drag_started()
@@ -40,7 +30,3 @@ static func get_block_class():
 
 static func get_scene_path():
 	return "res://addons/block_code/ui/blocks/control_block/control_block.tscn"
-
-
-func format():
-	arg_name_to_param_input_dict = StatementBlock.format_string(self, %RowHBox, definition.display_template, definition.defaults)

--- a/addons/block_code/ui/blocks/control_block/control_block.tscn
+++ b/addons/block_code/ui/blocks/control_block/control_block.tscn
@@ -1,18 +1,20 @@
-[gd_scene load_steps=6 format=3 uid="uid://bk2argmujy0kk"]
+[gd_scene load_steps=7 format=3 uid="uid://bk2argmujy0kk"]
 
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/control_block/control_block.gd" id="1_2hbir"]
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/utilities/background/gutter.gd" id="2_6o8pf"]
 [ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="2_lpu3c"]
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/utilities/background/background.gd" id="2_tx0qr"]
 [ext_resource type="PackedScene" uid="uid://b1oge52xhjqnu" path="res://addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn" id="3_nhryi"]
+[ext_resource type="PackedScene" uid="uid://b1xvp3u11h41s" path="res://addons/block_code/ui/blocks/utilities/template_editor/template_editor.tscn" id="4_6uktl"]
 
-[node name="ControlBlock" type="MarginContainer" node_paths=PackedStringArray("bottom_snap", "child_snap")]
+[node name="ControlBlock" type="MarginContainer" node_paths=PackedStringArray("bottom_snap", "child_snap", "template_editor")]
 size_flags_horizontal = 0
 focus_mode = 2
 mouse_filter = 2
 script = ExtResource("1_2hbir")
 bottom_snap = NodePath("VBoxContainer/SnapPoint")
 child_snap = NodePath("VBoxContainer/MarginContainer/Rows/SnapContainer/SnapPoint")
+template_editor = NodePath("VBoxContainer/MarginContainer/Rows/Row/RowHBoxContainer/TemplateEditor")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
@@ -57,11 +59,9 @@ theme_override_constants/margin_top = 6
 theme_override_constants/margin_right = 12
 theme_override_constants/margin_bottom = 6
 
-[node name="RowHBox" type="HBoxContainer" parent="VBoxContainer/MarginContainer/Rows/Row/RowHBoxContainer"]
+[node name="TemplateEditor" parent="VBoxContainer/MarginContainer/Rows/Row/RowHBoxContainer" instance=ExtResource("4_6uktl")]
 unique_name_in_owner = true
 layout_mode = 2
-mouse_filter = 2
-theme_override_constants/separation = 0
 
 [node name="SnapContainer" type="MarginContainer" parent="VBoxContainer/MarginContainer/Rows"]
 unique_name_in_owner = true
@@ -95,4 +95,5 @@ shift_top = 20.0
 [node name="SnapPoint" parent="VBoxContainer" instance=ExtResource("3_nhryi")]
 layout_mode = 2
 
+[connection signal="modified" from="." to="." method="_modified"]
 [connection signal="mouse_down" from="VBoxContainer/MarginContainer/Rows/Row/DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]

--- a/addons/block_code/ui/blocks/control_block/control_block.tscn
+++ b/addons/block_code/ui/blocks/control_block/control_block.tscn
@@ -95,5 +95,4 @@ shift_top = 20.0
 [node name="SnapPoint" parent="VBoxContainer" instance=ExtResource("3_nhryi")]
 layout_mode = 2
 
-[connection signal="modified" from="." to="." method="_modified"]
 [connection signal="mouse_down" from="VBoxContainer/MarginContainer/Rows/Row/DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]

--- a/addons/block_code/ui/blocks/entry_block/entry_block.tscn
+++ b/addons/block_code/ui/blocks/entry_block/entry_block.tscn
@@ -1,16 +1,18 @@
-[gd_scene load_steps=5 format=3 uid="uid://d2fibflv3ojys"]
+[gd_scene load_steps=6 format=3 uid="uid://d2fibflv3ojys"]
 
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/entry_block/entry_block.gd" id="2_3ik8h"]
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/utilities/background/background.gd" id="2_yrw8l"]
 [ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="3_v0qw8"]
+[ext_resource type="PackedScene" uid="uid://b1xvp3u11h41s" path="res://addons/block_code/ui/blocks/utilities/template_editor/template_editor.tscn" id="4_1gwsm"]
 [ext_resource type="PackedScene" uid="uid://b1oge52xhjqnu" path="res://addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn" id="4_yj206"]
 
-[node name="EntryBlock" type="MarginContainer" node_paths=PackedStringArray("child_snap")]
+[node name="EntryBlock" type="MarginContainer" node_paths=PackedStringArray("child_snap", "template_editor")]
 size_flags_horizontal = 0
 focus_mode = 2
 mouse_filter = 2
 script = ExtResource("2_3ik8h")
 child_snap = NodePath("VBoxContainer/SnapPoint")
+template_editor = NodePath("VBoxContainer/TopMarginContainer/MarginContainer/TemplateEditor")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
@@ -46,14 +48,12 @@ theme_override_constants/margin_top = 6
 theme_override_constants/margin_right = 12
 theme_override_constants/margin_bottom = 6
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TopMarginContainer/MarginContainer"]
+[node name="TemplateEditor" parent="VBoxContainer/TopMarginContainer/MarginContainer" instance=ExtResource("4_1gwsm")]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
-mouse_filter = 2
-theme_override_constants/separation = 0
 
 [node name="SnapPoint" parent="VBoxContainer" instance=ExtResource("4_yj206")]
 layout_mode = 2
 
 [connection signal="mouse_down" from="VBoxContainer/TopMarginContainer/DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]
+[connection signal="modified" from="VBoxContainer/TopMarginContainer/MarginContainer/TemplateEditor" to="." method="_modified"]

--- a/addons/block_code/ui/blocks/entry_block/entry_block.tscn
+++ b/addons/block_code/ui/blocks/entry_block/entry_block.tscn
@@ -56,4 +56,3 @@ layout_mode = 2
 layout_mode = 2
 
 [connection signal="mouse_down" from="VBoxContainer/TopMarginContainer/DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]
-[connection signal="modified" from="VBoxContainer/TopMarginContainer/MarginContainer/TemplateEditor" to="." method="_modified"]

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.gd
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.gd
@@ -4,11 +4,10 @@ extends Block
 
 const Constants = preload("res://addons/block_code/ui/constants.gd")
 const Util = preload("res://addons/block_code/ui/util.gd")
+const ParameterOutput = preload("res://addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.gd")
 
 @onready var _panel := $Panel
-@onready var _hbox := %HBoxContainer
 
-var arg_name_to_param_input_dict: Dictionary
 var args_to_add_after_format: Dictionary  # Only used when loading
 var spawned_by: ParameterOutput
 
@@ -30,16 +29,6 @@ func _ready():
 	if not Util.node_is_part_of_edited_scene(self):
 		_panel.add_theme_stylebox_override("panel", _panel_normal)
 
-	format()
-
-	for arg_name in arg_name_to_param_input_dict:
-		if arg_name in args_to_add_after_format:
-			var argument = args_to_add_after_format[arg_name]
-			if argument is Block:
-				arg_name_to_param_input_dict[arg_name].snap_point.add_child(argument)
-			else:
-				arg_name_to_param_input_dict[arg_name].set_raw_input(argument)
-
 
 func _on_drag_drop_area_mouse_down():
 	_drag_started()
@@ -51,10 +40,6 @@ static func get_block_class():
 
 static func get_scene_path():
 	return "res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"
-
-
-func format():
-	arg_name_to_param_input_dict = StatementBlock.format_string(self, %HBoxContainer, definition.display_template, definition.defaults)
 
 
 func _on_focus_entered():

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=4 format=3 uid="uid://clipm2dd28jde"]
+[gd_scene load_steps=5 format=3 uid="uid://clipm2dd28jde"]
 
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/parameter_block/parameter_block.gd" id="1_0hajy"]
 [ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="2_gy5co"]
+[ext_resource type="PackedScene" uid="uid://b1xvp3u11h41s" path="res://addons/block_code/ui/blocks/utilities/template_editor/template_editor.tscn" id="3_shl1a"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dbera"]
 bg_color = Color(1, 1, 1, 1)
@@ -14,13 +15,14 @@ corner_radius_top_right = 16
 corner_radius_bottom_right = 16
 corner_radius_bottom_left = 16
 
-[node name="ParameterBlock" type="MarginContainer"]
+[node name="ParameterBlock" type="MarginContainer" node_paths=PackedStringArray("template_editor")]
 offset_right = 16.0
 offset_bottom = 8.0
 size_flags_horizontal = 0
 focus_mode = 2
 mouse_filter = 2
 script = ExtResource("1_0hajy")
+template_editor = NodePath("MarginContainer/TemplateEditor")
 
 [node name="Panel" type="Panel" parent="."]
 unique_name_in_owner = true
@@ -32,18 +34,18 @@ layout_mode = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
-size_flags_horizontal = 0
 mouse_filter = 2
+
+[node name="TemplateEditor" parent="MarginContainer" instance=ExtResource("3_shl1a")]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 0
 theme_override_constants/margin_left = 10
 theme_override_constants/margin_top = 8
 theme_override_constants/margin_right = 10
 theme_override_constants/margin_bottom = 8
 
-[node name="HBoxContainer" type="HBoxContainer" parent="MarginContainer"]
-unique_name_in_owner = true
-layout_mode = 2
-mouse_filter = 2
-
 [connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
 [connection signal="focus_exited" from="." to="." method="_on_focus_exited"]
 [connection signal="mouse_down" from="DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]
+[connection signal="modified" from="MarginContainer/TemplateEditor" to="." method="_modified"]

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
@@ -48,4 +48,3 @@ theme_override_constants/margin_bottom = 8
 [connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
 [connection signal="focus_exited" from="." to="." method="_on_focus_exited"]
 [connection signal="mouse_down" from="DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]
-[connection signal="modified" from="MarginContainer/TemplateEditor" to="." method="_modified"]

--- a/addons/block_code/ui/blocks/statement_block/statement_block.gd
+++ b/addons/block_code/ui/blocks/statement_block/statement_block.gd
@@ -2,7 +2,6 @@
 class_name StatementBlock
 extends Block
 
-const BlocksCatalog = preload("res://addons/block_code/code_generation/blocks_catalog.gd")
 const ParameterInput = preload("res://addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd")
 const ParameterInputScene = preload("res://addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn")
 const ParameterOutput = preload("res://addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.gd")
@@ -10,7 +9,6 @@ const ParameterOutputScene = preload("res://addons/block_code/ui/blocks/utilitie
 const Types = preload("res://addons/block_code/types/types.gd")
 
 @onready var _background := %Background
-@onready var _hbox := %HBoxContainer
 
 var arg_name_to_param_input_dict: Dictionary
 var args_to_add_after_format: Dictionary  # Only used when loading
@@ -19,19 +17,9 @@ var args_to_add_after_format: Dictionary  # Only used when loading
 func _ready():
 	super()
 
-	if definition.type != Types.BlockType.STATEMENT:
+	if definition != null and definition.type != Types.BlockType.STATEMENT:
 		_background.show_top = false
 	_background.color = color
-
-	format()
-
-	for arg_name in arg_name_to_param_input_dict:
-		if arg_name in args_to_add_after_format:
-			var argument = args_to_add_after_format[arg_name]
-			if argument is Block:
-				arg_name_to_param_input_dict[arg_name].snap_point.add_child(argument)
-			else:
-				arg_name_to_param_input_dict[arg_name].set_raw_input(argument)
 
 
 func _on_drag_drop_area_mouse_down():
@@ -44,85 +32,3 @@ static func get_block_class():
 
 static func get_scene_path():
 	return "res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"
-
-
-func format():
-	arg_name_to_param_input_dict = format_string(self, %HBoxContainer, definition.display_template, definition.defaults)
-
-
-static func format_string(parent_block: Block, attach_to: Node, string: String, _defaults: Dictionary) -> Dictionary:
-	BlocksCatalog.setup()
-	var _arg_name_to_param_input_dict = {}
-	var regex = RegEx.new()
-	regex.compile("\\[([^\\]]+)\\]|\\{([^}]+)\\}")  # Capture things of format {test} or [test]
-	var results := regex.search_all(string)
-
-	var start: int = 0
-	for result in results:
-		var label_text := string.substr(start, result.get_start() - start)
-		if label_text != "":
-			var label = Label.new()
-			label.add_theme_color_override("font_color", Color.WHITE)
-			label.text = label_text
-			attach_to.add_child(label)
-
-		var param := result.get_string()
-		var copy_block: bool = param[0] == "["
-		param = param.substr(1, param.length() - 2)
-
-		var split := param.split(": ")
-		var param_name := split[0]
-		var param_type_str := split[1]
-
-		var param_type = null
-		var option := false
-		if param_type_str == "OPTION":  # Easy way to specify dropdown option
-			option = true
-		else:
-			param_type = Types.STRING_TO_VARIANT_TYPE[param_type_str]
-
-		var param_default = null
-		if _defaults.has(param_name):
-			param_default = _defaults[param_name]
-
-		var param_node: Node
-
-		if copy_block:
-			var parameter_output: ParameterOutput = ParameterOutputScene.instantiate()
-			parameter_output.name = "ParameterOutput%d" % start  # Unique path
-
-			var block_name = &"%s_%s" % [parent_block.definition.name, param_name]
-			var block_definition = BlocksCatalog.get_block(block_name)
-			if block_definition == null:
-				push_error("Could not locate block definition %s" % block_name)
-
-			parameter_output.block_params = {"definition": block_definition, "color": parent_block.color}
-			parameter_output.block = parent_block
-			attach_to.add_child(parameter_output)
-		else:
-			var parameter_input: ParameterInput = ParameterInputScene.instantiate()
-			parameter_input.name = "ParameterInput%d" % start  # Unique path
-			parameter_input.placeholder = param_name
-			if param_type != null:
-				parameter_input.variant_type = param_type
-			elif option:
-				parameter_input.option = true
-			parameter_input.modified.connect(func(): parent_block.modified.emit())
-
-			attach_to.add_child(parameter_input)
-
-			if param_default != null:
-				parameter_input.set_raw_input(param_default)
-
-			_arg_name_to_param_input_dict[param_name] = parameter_input
-
-		start = result.get_end()
-
-	var label_text := string.substr(start)
-	if label_text != "":
-		var label = Label.new()
-		label.add_theme_color_override("font_color", Color.WHITE)
-		label.text = label_text
-		attach_to.add_child(label)
-
-	return _arg_name_to_param_input_dict

--- a/addons/block_code/ui/blocks/statement_block/statement_block.tscn
+++ b/addons/block_code/ui/blocks/statement_block/statement_block.tscn
@@ -55,4 +55,3 @@ layout_mode = 2
 layout_mode = 2
 
 [connection signal="mouse_down" from="VBoxContainer/TopMarginContainer/DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]
-[connection signal="modified" from="VBoxContainer/TopMarginContainer/MarginContainer/TemplateEditor" to="." method="_modified"]

--- a/addons/block_code/ui/blocks/statement_block/statement_block.tscn
+++ b/addons/block_code/ui/blocks/statement_block/statement_block.tscn
@@ -1,16 +1,18 @@
-[gd_scene load_steps=5 format=3 uid="uid://c84vmg3odrtxt"]
+[gd_scene load_steps=6 format=3 uid="uid://c84vmg3odrtxt"]
 
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/statement_block/statement_block.gd" id="1_6wvlf"]
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/utilities/background/background.gd" id="2_lctqt"]
 [ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="2_owgdx"]
 [ext_resource type="PackedScene" uid="uid://b1oge52xhjqnu" path="res://addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn" id="3_5vaov"]
+[ext_resource type="PackedScene" uid="uid://b1xvp3u11h41s" path="res://addons/block_code/ui/blocks/utilities/template_editor/template_editor.tscn" id="4_vky23"]
 
-[node name="StatementBlock" type="MarginContainer" node_paths=PackedStringArray("bottom_snap")]
+[node name="StatementBlock" type="MarginContainer" node_paths=PackedStringArray("bottom_snap", "template_editor")]
 size_flags_horizontal = 0
 focus_mode = 2
 mouse_filter = 2
 script = ExtResource("1_6wvlf")
 bottom_snap = NodePath("VBoxContainer/SnapPoint")
+template_editor = NodePath("VBoxContainer/TopMarginContainer/MarginContainer/TemplateEditor")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 2
@@ -45,14 +47,12 @@ theme_override_constants/margin_top = 6
 theme_override_constants/margin_right = 12
 theme_override_constants/margin_bottom = 6
 
-[node name="HBoxContainer" type="HBoxContainer" parent="VBoxContainer/TopMarginContainer/MarginContainer"]
+[node name="TemplateEditor" parent="VBoxContainer/TopMarginContainer/MarginContainer" instance=ExtResource("4_vky23")]
 unique_name_in_owner = true
-custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
-mouse_filter = 2
-theme_override_constants/separation = 0
 
 [node name="SnapPoint" parent="VBoxContainer" instance=ExtResource("3_5vaov")]
 layout_mode = 2
 
 [connection signal="mouse_down" from="VBoxContainer/TopMarginContainer/DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]
+[connection signal="modified" from="VBoxContainer/TopMarginContainer/MarginContainer/TemplateEditor" to="." method="_modified"]

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
@@ -244,7 +244,18 @@ func _update_option_input(current_value: Variant = null):
 		if item == current_value:
 			selected_item_index = item_index
 
-	if _option_input.item_count == 0:
+	if selected_item_index == -1 and current_value:
+		# If the current value is not in the default list of options, add it
+		# and select it.
+		if _option_input.item_count > 0:
+			_option_input.add_separator()
+		var item_index = _option_input.item_count
+		var option_label = current_value.capitalize() if current_value is String else str(current_value)
+		_option_input.add_item(option_label)
+		_option_input.set_item_tooltip(item_index, current_value)
+		_option_input.set_item_metadata(item_index, current_value)
+		selected_item_index = item_index
+	elif _option_input.item_count == 0:
 		var item_index = _option_input.item_count
 		_option_input.add_item("<%s>" % placeholder)
 		_option_input.set_item_disabled(item_index, true)

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn
@@ -87,6 +87,7 @@ custom_minimum_size = Vector2(40, 0)
 layout_mode = 2
 tooltip_text = "Parameter"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_fjquj")
+fit_to_longest_item = false
 
 [node name="Vector2Input" type="MarginContainer" parent="InputSwitcher"]
 unique_name_in_owner = true

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn
@@ -10,11 +10,11 @@ corner_radius_top_right = 40
 corner_radius_bottom_right = 40
 corner_radius_bottom_left = 40
 
-[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_6oowp"]
-
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_afyv2"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_3r4mt"]
+
+[sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_6oowp"]
 
 [sub_resource type="StyleBoxEmpty" id="StyleBoxEmpty_5hq7f"]
 
@@ -60,13 +60,13 @@ theme_override_constants/margin_bottom = 4
 unique_name_in_owner = true
 layout_mode = 2
 mouse_filter = 1
-theme_override_colors/font_color = Color(0.118581, 0.118581, 0.118581, 1)
-theme_override_colors/font_uneditable_color = Color(0.117647, 0.117647, 0.117647, 1)
 theme_override_colors/font_placeholder_color = Color(0.76662, 0.76662, 0.76662, 1)
+theme_override_colors/font_uneditable_color = Color(0.117647, 0.117647, 0.117647, 1)
+theme_override_colors/font_color = Color(0.118581, 0.118581, 0.118581, 1)
 theme_override_constants/minimum_character_width = 0
-theme_override_styles/normal = SubResource("StyleBoxEmpty_6oowp")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_afyv2")
 theme_override_styles/read_only = SubResource("StyleBoxEmpty_3r4mt")
+theme_override_styles/normal = SubResource("StyleBoxEmpty_6oowp")
 placeholder_text = "Parameter"
 expand_to_text_length = true
 
@@ -106,13 +106,13 @@ size_flags_horizontal = 3
 unique_name_in_owner = true
 layout_mode = 2
 mouse_filter = 1
-theme_override_colors/font_color = Color(0.118581, 0.118581, 0.118581, 1)
-theme_override_colors/font_uneditable_color = Color(0.117647, 0.117647, 0.117647, 1)
 theme_override_colors/font_placeholder_color = Color(0.76662, 0.76662, 0.76662, 1)
+theme_override_colors/font_uneditable_color = Color(0.117647, 0.117647, 0.117647, 1)
+theme_override_colors/font_color = Color(0.118581, 0.118581, 0.118581, 1)
 theme_override_constants/minimum_character_width = 0
-theme_override_styles/normal = SubResource("StyleBoxEmpty_6oowp")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_afyv2")
 theme_override_styles/read_only = SubResource("StyleBoxEmpty_3r4mt")
+theme_override_styles/normal = SubResource("StyleBoxEmpty_6oowp")
 placeholder_text = "x"
 alignment = 1
 expand_to_text_length = true
@@ -139,13 +139,13 @@ size_flags_horizontal = 3
 unique_name_in_owner = true
 layout_mode = 2
 mouse_filter = 1
-theme_override_colors/font_color = Color(0.118581, 0.118581, 0.118581, 1)
-theme_override_colors/font_uneditable_color = Color(0.117647, 0.117647, 0.117647, 1)
 theme_override_colors/font_placeholder_color = Color(0.76662, 0.76662, 0.76662, 1)
+theme_override_colors/font_uneditable_color = Color(0.117647, 0.117647, 0.117647, 1)
+theme_override_colors/font_color = Color(0.118581, 0.118581, 0.118581, 1)
 theme_override_constants/minimum_character_width = 0
-theme_override_styles/normal = SubResource("StyleBoxEmpty_6oowp")
 theme_override_styles/focus = SubResource("StyleBoxEmpty_afyv2")
 theme_override_styles/read_only = SubResource("StyleBoxEmpty_3r4mt")
+theme_override_styles/normal = SubResource("StyleBoxEmpty_6oowp")
 placeholder_text = "y"
 alignment = 1
 expand_to_text_length = true
@@ -164,14 +164,13 @@ theme_override_constants/margin_left = 8
 unique_name_in_owner = true
 custom_minimum_size = Vector2(60, 0)
 layout_mode = 2
-theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_colors/font_focus_color = Color(0, 0, 0, 1)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
 theme_override_styles/focus = SubResource("StyleBoxEmpty_e7f0k")
 theme_override_styles/normal = SubResource("StyleBoxEmpty_fjquj")
-item_count = 2
 selected = 0
+item_count = 2
 popup/item_0/text = "False"
-popup/item_0/id = 0
 popup/item_1/text = "True"
 popup/item_1/id = 1
 

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn
@@ -42,6 +42,7 @@ theme_override_styles/panel = SubResource("StyleBoxFlat_tn6h4")
 [node name="InputSwitcher" type="MarginContainer" parent="."]
 unique_name_in_owner = true
 layout_mode = 2
+tooltip_text = "Parameter"
 mouse_filter = 2
 theme_override_constants/margin_left = 0
 theme_override_constants/margin_top = 0
@@ -84,6 +85,7 @@ unique_name_in_owner = true
 visible = false
 custom_minimum_size = Vector2(40, 0)
 layout_mode = 2
+tooltip_text = "Parameter"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_fjquj")
 
 [node name="Vector2Input" type="MarginContainer" parent="InputSwitcher"]

--- a/addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.gd
@@ -1,11 +1,13 @@
 @tool
-class_name ParameterOutput
 extends MarginContainer
 
 const Types = preload("res://addons/block_code/types/types.gd")
+const ParameterBlock = preload("res://addons/block_code/ui/blocks/parameter_block/parameter_block.gd")
+const ParameterBlockScene = preload("res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn")
 
 var block: Block
 var parameter_name: String
+var output_block: Block
 var _block_name: String:
 	get:
 		return block.definition.name if block else ""
@@ -18,12 +20,13 @@ var _block_name: String:
 
 
 func _ready():
-	_snap_point.block_type = Types.BlockType.NONE
-
 	_update_parameter_block.call_deferred()
 
 
 func _update_parameter_block():
+	if _snap_point == null:
+		return
+
 	if _snap_point.has_snapped_block():
 		return
 

--- a/addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.gd
@@ -5,9 +5,14 @@ extends MarginContainer
 const Types = preload("res://addons/block_code/types/types.gd")
 
 var block: Block
-var output_block: Block
+var parameter_name: String
+var _block_name: String:
+	get:
+		return block.definition.name if block else ""
 
 @export var block_params: Dictionary
+
+@onready var _context := BlockEditorContext.get_default()
 
 @onready var _snap_point := %SnapPoint
 
@@ -22,10 +27,17 @@ func _update_parameter_block():
 	if _snap_point.has_snapped_block():
 		return
 
-	var parameter_block = preload("res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn").instantiate()
-	for key in block_params:
-		parameter_block[key] = block_params[key]
-	parameter_block.spawned_by = self
+	if _context.block_script == null:
+		return
+
+	var block_name = &"%s:%s" % [_block_name, parameter_name]
+	var parameter_block: ParameterBlock = _context.block_script.instantiate_block_by_name(block_name)
+
+	if parameter_block == null:
+		# FIXME: This sometimes occurs when a script is loaded but it is unclear why
+		#push_error("Unable to create output block %s." % block_name)
+		return
+
 	_snap_point.add_child.call_deferred(parameter_block)
 
 

--- a/addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.tscn
+++ b/addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.tscn
@@ -27,12 +27,10 @@ layout_mode = 2
 mouse_filter = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_tn6h4")
 
-[node name="SnapPoint" parent="." node_paths=PackedStringArray("snapped_block") instance=ExtResource("2_ngr7c")]
+[node name="SnapPoint" parent="." instance=ExtResource("2_ngr7c")]
 unique_name_in_owner = true
 layout_mode = 2
-mouse_filter = 2
 block_type = 0
-snapped_block = NodePath("ParameterBlock")
 variant_type = 4
 
 [connection signal="child_exiting_tree" from="." to="SnapPoint" method="_on_parameter_output_child_exiting_tree"]

--- a/addons/block_code/ui/blocks/utilities/snap_point/snap_point.gd
+++ b/addons/block_code/ui/blocks/utilities/snap_point/snap_point.gd
@@ -49,6 +49,16 @@ func has_snapped_block() -> bool:
 	return snapped_block != null
 
 
+func replace_snapped_block(new_block: Block):
+	var old_block = get_snapped_block()
+
+	if old_block:
+		remove_child(old_block)
+
+	if new_block:
+		add_child(new_block)
+
+
 func insert_snapped_block(new_block: Block) -> Block:
 	var old_block = get_snapped_block()
 

--- a/addons/block_code/ui/blocks/utilities/template_editor/template_editor.gd
+++ b/addons/block_code/ui/blocks/utilities/template_editor/template_editor.gd
@@ -1,0 +1,132 @@
+@tool
+class_name TemplateEditor
+extends Container
+
+signal modified
+
+const BlockDefinition = preload("res://addons/block_code/code_generation/block_definition.gd")
+const BlockTreeUtil = preload("res://addons/block_code/ui/block_tree_util.gd")
+const OptionData = preload("res://addons/block_code/code_generation/option_data.gd")
+const ParameterInput = preload("res://addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd")
+const ParameterInputScene = preload("res://addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn")
+const ParameterOutput = preload("res://addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.gd")
+const ParameterOutputScene = preload("res://addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.tscn")
+
+const FORMAT_STRING_PATTERN = "\\[(?<out_parameter>[^\\]]+)\\]|\\{(?<in_parameter>[^}]+)\\}|(?<label>[^\\{\\[]+)"
+
+## A string describing a block's display format. For example:
+## [br]
+## [code]
+## Print {text: STRING}
+## [/code]
+## [br]
+## This component's children will be generated based on the format string,
+## with [code]ParameterInput[/code] and [code]ParameterOutput[/code] nodes in
+## place of any parameters of format [code]{foo}[/code] or [code][foo][/code].
+@export var format_string: String:
+	set(value):
+		format_string = value
+		_update_from_format_string()
+
+## A dictionary describing default values for a block's parameters. The keys of
+## the dictionary must match the list of parameters in [param format_string].
+## The values should be the same type as the parameter.
+@export var parameter_defaults: Dictionary:
+	set(value):
+		parameter_defaults = value
+		_update_from_format_string()
+
+var parent_block: Block
+var _parameter_inputs_by_name: Dictionary
+
+@onready var _container := %Container
+@onready var _regex := RegEx.create_from_string(FORMAT_STRING_PATTERN)
+
+
+func _ready() -> void:
+	parent_block = BlockTreeUtil.get_parent_block(self)
+
+	_update_from_format_string()
+
+
+## Set the values of all input parameters based from a dictionary of raw values.
+## Parameters not included in [param raw_values] will be reset to their
+## defaults according to [member parameter_defaults].
+func set_parameter_values(raw_values: Dictionary):
+	for parameter_name in _parameter_inputs_by_name:
+		var parameter_input: ParameterInput = _parameter_inputs_by_name[parameter_name]
+		var parameter_value: Variant = raw_values.get(parameter_name)
+
+		parameter_input.set_raw_input(parameter_value)
+
+
+func get_parameter_values() -> Dictionary:
+	var result: Dictionary
+
+	for parameter_name in _parameter_inputs_by_name:
+		var parameter_input: ParameterInput = _parameter_inputs_by_name[parameter_name]
+		result[parameter_name] = parameter_input.get_raw_input()
+
+	return result
+
+
+func format_statement(statement: String) -> String:
+	return _parameter_inputs_by_name.keys().reduce(_replace_parameter_in_statement, statement)
+
+
+func _replace_parameter_in_statement(statement: String, parameter_name: String) -> String:
+	var parameter_input: ParameterInput = _parameter_inputs_by_name[parameter_name]
+	return statement.replace("{%s}" % parameter_name, parameter_input.get_string())
+
+
+func _update_from_format_string():
+	if not _container:
+		return
+
+	_parameter_inputs_by_name = {}
+	for child in _container.get_children():
+		_container.remove_child(child)
+		child.queue_free()
+
+	var match_id = 0
+	for item in BlockDefinition.parse_display_template(format_string):
+		if item.has("label"):
+			_append_label(item.get("label"))
+		elif item.has("in_parameter"):
+			_append_input_parameter(item.get("in_parameter"), match_id)
+		elif item.has("out_parameter"):
+			_append_output_parameter(item.get("out_parameter"), match_id)
+		match_id += 1
+
+
+func _append_label(label_format: String):
+	var label = Label.new()
+	label.add_theme_color_override("font_color", Color.WHITE)
+	label.text = label_format.strip_edges()
+	_container.add_child(label)
+
+
+func _append_input_parameter(parameter: Dictionary, id: int):
+	var default_value = parameter_defaults.get(parameter["name"])
+
+	var parameter_input: ParameterInput = ParameterInputScene.instantiate()
+	parameter_input.name = "ParameterInput%d" % id
+	parameter_input.placeholder = parameter["name"]
+	parameter_input.variant_type = parameter["type"]
+	parameter_input.option = parameter["is_option"]
+	parameter_input.default_value = default_value
+
+	parameter_input.modified.connect(func(): modified.emit())
+
+	_container.add_child(parameter_input)
+	_parameter_inputs_by_name[parameter["name"]] = parameter_input
+
+
+func _append_output_parameter(parameter: Dictionary, id: int):
+	var parameter_output: ParameterOutput
+
+	parameter_output = ParameterOutputScene.instantiate()
+	parameter_output.name = "ParameterOutput%d" % id
+	parameter_output.block = parent_block
+	parameter_output.parameter_name = parameter["name"]
+	_container.add_child(parameter_output)

--- a/addons/block_code/ui/blocks/utilities/template_editor/template_editor.gd
+++ b/addons/block_code/ui/blocks/utilities/template_editor/template_editor.gd
@@ -114,13 +114,11 @@ func _append_input_parameter(parameter: Dictionary, id: int):
 	parameter_input.placeholder = parameter["name"]
 	parameter_input.variant_type = parameter["type"]
 
-	if parameter["is_option"] and default_value is OptionData:
+	if default_value is OptionData:
 		var option_data := default_value as OptionData
 		parameter_input.option_data = option_data
 		if option_data.selected < option_data.items.size():
 			parameter_input.default_value = option_data.items[option_data.selected]
-	elif parameter["is_option"]:
-		push_warning("The block parameter %s in %s appears to be an option, but no option data is provided" % [parameter_format, parent_block])
 	else:
 		parameter_input.default_value = default_value
 

--- a/addons/block_code/ui/blocks/utilities/template_editor/template_editor.gd
+++ b/addons/block_code/ui/blocks/utilities/template_editor/template_editor.gd
@@ -113,8 +113,16 @@ func _append_input_parameter(parameter: Dictionary, id: int):
 	parameter_input.name = "ParameterInput%d" % id
 	parameter_input.placeholder = parameter["name"]
 	parameter_input.variant_type = parameter["type"]
-	parameter_input.option = parameter["is_option"]
-	parameter_input.default_value = default_value
+
+	if parameter["is_option"] and default_value is OptionData:
+		var option_data := default_value as OptionData
+		parameter_input.option_data = option_data
+		if option_data.selected < option_data.items.size():
+			parameter_input.default_value = option_data.items[option_data.selected]
+	elif parameter["is_option"]:
+		push_warning("The block parameter %s in %s appears to be an option, but no option data is provided" % [parameter_format, parent_block])
+	else:
+		parameter_input.default_value = default_value
 
 	parameter_input.modified.connect(func(): modified.emit())
 

--- a/addons/block_code/ui/blocks/utilities/template_editor/template_editor.tscn
+++ b/addons/block_code/ui/blocks/utilities/template_editor/template_editor.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=2 format=3 uid="uid://b1xvp3u11h41s"]
+
+[ext_resource type="Script" path="res://addons/block_code/ui/blocks/utilities/template_editor/template_editor.gd" id="1_7extq"]
+
+[node name="TemplateEditor" type="MarginContainer"]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+script = ExtResource("1_7extq")
+
+[node name="Container" type="HBoxContainer" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+mouse_filter = 2

--- a/addons/block_code/ui/main_panel.gd
+++ b/addons/block_code/ui/main_panel.gd
@@ -5,10 +5,13 @@ signal script_window_requested(script: String)
 
 const BlockCanvas = preload("res://addons/block_code/ui/block_canvas/block_canvas.gd")
 const BlockCodePlugin = preload("res://addons/block_code/block_code_plugin.gd")
+const BlocksCatalog = preload("res://addons/block_code/code_generation/blocks_catalog.gd")
 const DragManager = preload("res://addons/block_code/drag_manager/drag_manager.gd")
 const Picker = preload("res://addons/block_code/ui/picker/picker.gd")
 const TitleBar = preload("res://addons/block_code/ui/title_bar/title_bar.gd")
 const VariableDefinition = preload("res://addons/block_code/code_generation/variable_definition.gd")
+
+@onready var _context := BlockEditorContext.get_default()
 
 @onready var _picker: Picker = %Picker
 @onready var _block_canvas: BlockCanvas = %BlockCanvas
@@ -25,7 +28,6 @@ const VariableDefinition = preload("res://addons/block_code/code_generation/vari
 
 const Constants = preload("res://addons/block_code/ui/constants.gd")
 
-var _current_block_code_node: BlockCode
 var _block_code_nodes: Array
 var _collapsed: bool = false
 
@@ -39,6 +41,8 @@ var undo_redo: EditorUndoRedoManager:
 
 
 func _ready():
+	_context.changed.connect(_on_context_changed)
+
 	_picker.block_picked.connect(_drag_manager.copy_picked_block_and_drag)
 	_picker.variable_created.connect(_create_variable)
 	_block_canvas.reconnect_block.connect(_drag_manager.connect_block_canvas_signals)
@@ -52,13 +56,7 @@ func _ready():
 
 
 func _on_undo_redo_version_changed():
-	if _current_block_code_node == null:
-		return
-
-	var block_script: BlockScriptSerialization = _current_block_code_node.block_script
-	_picker.block_script_selected(block_script)
-	_title_bar.block_script_selected(block_script)
-	_block_canvas.block_script_selected(block_script)
+	_context.force_update()
 
 
 func _on_show_script_button_pressed():
@@ -73,15 +71,14 @@ func _on_delete_node_button_pressed():
 	if not scene_root:
 		return
 
-	if not _current_block_code_node:
+	if not _context.block_code_node:
 		return
 
 	var dialog = ConfirmationDialog.new()
 	var text_format: String = 'Delete block code ("{node}") for "{parent}"?'
-	dialog.dialog_text = text_format.format({"node": _current_block_code_node.name, "parent": _current_block_code_node.get_parent().name})
+	dialog.dialog_text = text_format.format({"node": _context.block_code_node.name, "parent": _context.parent_node.name})
 	EditorInterface.popup_dialog_centered(dialog)
-	dialog.connect("confirmed", _on_delete_dialog_confirmed.bind(_current_block_code_node))
-	pass  # Replace with function body.
+	dialog.connect("confirmed", _on_delete_dialog_confirmed.bind(_context.block_code_node))
 
 
 func _on_delete_dialog_confirmed(block_code_node: BlockCode):
@@ -90,7 +87,7 @@ func _on_delete_dialog_confirmed(block_code_node: BlockCode):
 	if not parent_node:
 		return
 
-	undo_redo.create_action("Delete %s's block code script" % _current_block_code_node.get_parent().name, UndoRedo.MERGE_DISABLE, parent_node)
+	undo_redo.create_action("Delete %s's block code script" % parent_node.name, UndoRedo.MERGE_DISABLE, parent_node)
 	undo_redo.add_do_property(block_code_node, "owner", null)
 	undo_redo.add_do_method(parent_node, "remove_child", block_code_node)
 	undo_redo.add_undo_method(parent_node, "add_child", block_code_node)
@@ -100,53 +97,59 @@ func _on_delete_dialog_confirmed(block_code_node: BlockCode):
 
 
 func _try_migration():
-	var version: int = _current_block_code_node.block_script.version
+	var version: int = _context.block_script.version
 	if version == Constants.CURRENT_DATA_VERSION:
 		# No migration needed.
 		return
 	push_warning("Migration not implemented from %d to %d" % [version, Constants.CURRENT_DATA_VERSION])
 
 
-func switch_scene(scene_root: Node):
-	_title_bar.scene_selected(scene_root)
-
-
 func switch_block_code_node(block_code_node: BlockCode):
-	var block_script: BlockScriptSerialization = block_code_node.block_script if block_code_node else null
-	_current_block_code_node = block_code_node
-	_delete_node_button.disabled = _current_block_code_node == null
-	if _current_block_code_node != null:
+	BlocksCatalog.setup()
+
+	var block_script := block_code_node.block_script if block_code_node != null else null
+	var object_script := block_script.load_object_script() if block_script != null else null
+
+	if object_script and object_script.has_method("setup_custom_blocks"):
+		object_script.setup_custom_blocks()
+
+	if block_script:
+		block_script.initialize()
+
+	_context.block_code_node = block_code_node
+
+
+func _on_context_changed():
+	_delete_node_button.disabled = _context.block_code_node == null
+	if _context.block_code_node != null:
 		_try_migration()
-	_picker.block_script_selected(block_script)
-	_title_bar.block_script_selected(block_script)
-	_block_canvas.block_script_selected(block_script)
 
 
 func save_script():
-	if _current_block_code_node == null:
+	if _context.block_code_node == null:
 		print("No script loaded to save.")
 		return
 
 	var scene_node = EditorInterface.get_edited_scene_root()
 
-	if not BlockCodePlugin.is_block_code_editable(_current_block_code_node):
-		print("Block code for {node} is not editable.".format({"node": _current_block_code_node}))
+	if not BlockCodePlugin.is_block_code_editable(_context.block_code_node):
+		print("Block code for {node} is not editable.".format({"node": _context.block_code_node}))
 		return
 
-	var block_script: BlockScriptSerialization = _current_block_code_node.block_script
+	var block_script: BlockScriptSerialization = _context.block_script
 
 	var resource_path_split = block_script.resource_path.split("::", true, 1)
 	var resource_scene = resource_path_split[0]
 
-	undo_redo.create_action("Modify %s's block code script" % _current_block_code_node.get_parent().name, UndoRedo.MERGE_DISABLE, _current_block_code_node)
+	undo_redo.create_action("Modify %s's block code script" % _context.parent_node.name, UndoRedo.MERGE_DISABLE, _context.block_code_node)
 
 	if resource_scene and resource_scene != scene_node.scene_file_path:
 		# This resource is from another scene. Since the user is changing it
 		# here, we'll make a copy for this scene rather than changing it in the
 		# other scene file.
-		undo_redo.add_undo_property(_current_block_code_node, "block_script", _current_block_code_node.block_script)
+		undo_redo.add_undo_property(_context.block_code_node, "block_script", _context.block_script)
 		block_script = block_script.duplicate(true)
-		undo_redo.add_do_property(_current_block_code_node, "block_script", block_script)
+		undo_redo.add_do_property(_context.block_code_node, "block_script", block_script)
 
 	undo_redo.add_undo_property(block_script, "block_serialization_trees", block_script.block_serialization_trees)
 	_block_canvas.rebuild_ast_list()
@@ -264,19 +267,19 @@ func _set_selection(nodes: Array[Node]):
 
 
 func _create_variable(variable: VariableDefinition):
-	if _current_block_code_node == null:
+	if _context.block_code_node == null:
 		print("No script loaded to add variable to.")
 		return
 
-	var block_script: BlockScriptSerialization = _current_block_code_node.block_script
+	var block_script: BlockScriptSerialization = _context.block_script
 
-	undo_redo.create_action("Create variable %s in %s's block code script" % [variable.var_name, _current_block_code_node.get_parent().name])
-	undo_redo.add_undo_property(_current_block_code_node.block_script, "variables", _current_block_code_node.block_script.variables)
+	undo_redo.create_action("Create variable %s in %s's block code script" % [variable.var_name, _context.parent_node.name])
+	undo_redo.add_undo_property(_context.block_script, "variables", _context.block_script.variables)
 
 	var new_variables = block_script.variables.duplicate()
 	new_variables.append(variable)
 
-	undo_redo.add_do_property(_current_block_code_node.block_script, "variables", new_variables)
+	undo_redo.add_do_property(_context.block_script, "variables", new_variables)
 	undo_redo.commit_action()
 
-	_picker.reload_variables(new_variables)
+	_picker.reload_blocks()

--- a/addons/block_code/ui/picker/categories/block_category.gd
+++ b/addons/block_code/ui/picker/categories/block_category.gd
@@ -1,15 +1,18 @@
 extends RefCounted
 
-const BlockDefinition = preload("res://addons/block_code/code_generation/block_definition.gd")
-
 var name: String
-var block_list: Array[BlockDefinition]
 var color: Color
 var order: int
 
 
-func _init(p_name: String = "", p_color: Color = Color.WHITE, p_order: int = 0, p_block_list: Array[BlockDefinition] = []):
+func _init(p_name: String = "", p_color: Color = Color.WHITE, p_order: int = 0):
 	name = p_name
-	block_list = p_block_list
 	color = p_color
 	order = p_order
+
+
+## Compare block categories for sorting. Compare by order then name.
+static func sort_by_order(a, b) -> bool:
+	if a.order != b.order:
+		return a.order < b.order
+	return a.name.naturalcasecmp_to(b.name) < 0

--- a/addons/block_code/ui/picker/categories/block_category_display.gd
+++ b/addons/block_code/ui/picker/categories/block_category_display.gd
@@ -8,15 +8,20 @@ const Util = preload("res://addons/block_code/ui/util.gd")
 
 var category: BlockCategory
 
+@onready var _context := BlockEditorContext.get_default()
+
 @onready var _label := %Label
 @onready var _blocks := %Blocks
 
 
 func _ready():
-	_label.text = category.name
+	_label.text = category.name if category != null else ""
 
-	for block_definition in category.block_list:
-		var block: Block = Util.instantiate_block(block_definition)
+	if _context.block_script == null:
+		return
+
+	for block_definition in _context.block_script.get_blocks_in_category(category):
+		var block: Block = _context.block_script.instantiate_block(block_definition)
 
 		block.color = category.color
 		block.can_delete = false

--- a/addons/block_code/ui/picker/categories/category_factory.gd
+++ b/addons/block_code/ui/picker/categories/category_factory.gd
@@ -2,105 +2,20 @@ class_name CategoryFactory
 extends Object
 
 const BlockCategory = preload("res://addons/block_code/ui/picker/categories/block_category.gd")
-const BlockDefinition = preload("res://addons/block_code/code_generation/block_definition.gd")
-const BlocksCatalog = preload("res://addons/block_code/code_generation/blocks_catalog.gd")
-const Types = preload("res://addons/block_code/types/types.gd")
-const Util = preload("res://addons/block_code/ui/util.gd")
 const Constants = preload("res://addons/block_code/ui/constants.gd")
 
 
-## Compare block categories for sorting. Compare by order then name.
-static func _category_cmp(a: BlockCategory, b: BlockCategory) -> bool:
-	if a.order != b.order:
-		return a.order < b.order
-	return a.name.naturalcasecmp_to(b.name) < 0
+## Returns a list of BlockCategory instances for all block categories.
+static func get_all_categories(custom_categories: Array[BlockCategory] = []) -> Array[BlockCategory]:
+	var result: Array[BlockCategory]
 
+	for category_name in Constants.BUILTIN_CATEGORIES_PROPS:
+		var props: Dictionary = Constants.BUILTIN_CATEGORIES_PROPS.get(category_name, {})
+		var color: Color = props.get("color", Color.SLATE_GRAY)
+		var order: int = props.get("order", 0)
+		result.append(BlockCategory.new(category_name, color, order))
 
-static func get_categories(blocks: Array[BlockDefinition], extra_categories: Array[BlockCategory] = []) -> Array[BlockCategory]:
-	var cat_map: Dictionary = {}
-	var extra_cat_map: Dictionary = {}
+	# TODO: Should we deduplicate custom_categories here?
+	result.append_array(custom_categories)
 
-	for cat in extra_categories:
-		extra_cat_map[cat.name] = cat
-
-	for block in blocks:
-		var cat: BlockCategory = cat_map.get(block.category)
-		if cat == null:
-			cat = extra_cat_map.get(block.category)
-			if cat == null:
-				var props: Dictionary = Constants.BUILTIN_CATEGORIES_PROPS.get(block.category, {})
-				var color: Color = props.get("color", Color.SLATE_GRAY)
-				var order: int = props.get("order", 0)
-				cat = BlockCategory.new(block.category, color, order)
-			cat_map[block.category] = cat
-		cat.block_list.append(block)
-
-	# Dictionary.values() returns an untyped Array and there's no way to
-	# convert an array type besides Array.assign().
-	var cats: Array[BlockCategory] = []
-	cats.assign(cat_map.values())
-	# Accessing a static Callable from a static function fails in 4.2.1.
-	# Use the fully qualified name.
-	# https://github.com/godotengine/godot/issues/86032
-	cats.sort_custom(CategoryFactory._category_cmp)
-	return cats
-
-
-static func get_general_blocks() -> Array[BlockDefinition]:
-	var block: BlockDefinition
-	var block_list: Array[BlockDefinition] = []
-
-	BlocksCatalog.setup()
-
-	# Lifecycle
-	for block_name in [&"ready", &"process", &"physics_process", &"queue_free"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	# Loops
-	for block_name in [&"for", &"while", &"break", &"continue", &"await_scene_ready"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	# Logs
-	block = BlocksCatalog.get_block(&"print")
-	block_list.append(block)
-
-	# Communication
-	for block_name in [&"define_method", &"call_method_group", &"call_method_node"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	for block_name in [&"add_to_group", &"add_node_to_group", &"remove_from_group", &"remove_node_from_group", &"is_in_group", &"is_node_in_group"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	# Variables
-	block = BlocksCatalog.get_block(&"vector2")
-	block_list.append(block)
-
-	# Math
-	for block_name in [&"add", &"subtract", &"multiply", &"divide", &"pow", &"randf_range", &"randi_range", &"sin", &"cos", &"tan"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	# Logic
-	for block_name in [&"if", &"else_if", &"else", &"compare", &"and", &"or", &"not"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	# Input
-	block = BlocksCatalog.get_block(&"is_input_actioned")
-	block_list.append(block)
-
-	# Sounds
-	for block_name in [&"load_sound", &"play_sound", &"pause_continue_sound", &"stop_sound"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	# Graphics
-	for block_name in [&"viewport_width", &"viewport_height", &"viewport_center"]:
-		block = BlocksCatalog.get_block(block_name)
-		block_list.append(block)
-
-	return block_list
+	return result

--- a/addons/block_code/ui/picker/categories/variable_category/create_variable_dialog.gd
+++ b/addons/block_code/ui/picker/categories/variable_category/create_variable_dialog.gd
@@ -5,6 +5,8 @@ const BlockCodePlugin = preload("res://addons/block_code/block_code_plugin.gd")
 
 signal create_variable(var_name: String, var_type: String)
 
+@onready var _context := BlockEditorContext.get_default()
+
 @onready var _variable_input := %VariableInput
 @onready var _type_option := %TypeOption
 @onready var _messages := %Messages
@@ -60,14 +62,11 @@ func check_errors(new_var_name: String) -> bool:
 		errors.append("Variable name cannot contain special characters")
 
 	var duplicate_variable_name := false
-	var current_block_code = BlockCodePlugin.main_panel._current_block_code_node
-	if current_block_code:
-		var current_block_script = current_block_code.block_script
-		if current_block_script:
-			for variable in current_block_script.variables:
-				if variable.var_name == new_var_name:
-					duplicate_variable_name = true
-					break
+	if _context.block_script:
+		for variable in _context.block_script.variables:
+			if variable.var_name == new_var_name:
+				duplicate_variable_name = true
+				break
 
 	if duplicate_variable_name:
 		errors.append("Variable already exists")

--- a/addons/block_code/ui/picker/picker.gd
+++ b/addons/block_code/ui/picker/picker.gd
@@ -6,13 +6,14 @@ const BlockCategory = preload("res://addons/block_code/ui/picker/categories/bloc
 const BlockCategoryButtonScene = preload("res://addons/block_code/ui/picker/categories/block_category_button.tscn")
 const BlockCategoryButton = preload("res://addons/block_code/ui/picker/categories/block_category_button.gd")
 const BlockCategoryDisplay = preload("res://addons/block_code/ui/picker/categories/block_category_display.gd")
-const CategoryFactory = preload("res://addons/block_code/ui/picker/categories/category_factory.gd")
 const Util = preload("res://addons/block_code/ui/util.gd")
 const VariableCategoryDisplay = preload("res://addons/block_code/ui/picker/categories/variable_category/variable_category_display.gd")
 const VariableDefinition = preload("res://addons/block_code/code_generation/variable_definition.gd")
 
 signal block_picked(block: Block)
 signal variable_created(variable: VariableDefinition)
+
+@onready var _context := BlockEditorContext.get_default()
 
 @onready var _block_list := %BlockList
 @onready var _block_scroll := %BlockScroll
@@ -23,35 +24,31 @@ var scroll_tween: Tween
 var _variable_category_display: VariableCategoryDisplay = null
 
 
-func block_script_selected(block_script: BlockScriptSerialization):
-	if not block_script:
-		reset_picker()
+func _ready() -> void:
+	_context.changed.connect(_on_context_changed)
+
+
+func _on_context_changed():
+	_block_scroll.scroll_vertical = 0
+	_update_block_components()
+
+
+func reload_blocks():
+	_update_block_components()
+
+
+func _update_block_components():
+	# FIXME: Instead, we should reuse existing CategoryList and BlockList components.
+	_reset_picker()
+
+	if not _context.block_script:
 		return
 
-	var blocks_to_add: Array[BlockDefinition] = block_script.get_definitions()
-	var categories_to_add: Array[BlockCategory] = block_script.get_categories()
+	var block_categories := _context.block_script.get_available_categories()
 
-	init_picker(blocks_to_add, categories_to_add)
-	reload_variables(block_script.variables)
+	block_categories.sort_custom(BlockCategory.sort_by_order)
 
-
-func reset_picker():
-	for c in _category_list.get_children():
-		c.queue_free()
-
-	for c in _block_list.get_children():
-		c.queue_free()
-
-
-func init_picker(extra_blocks: Array[BlockDefinition] = [], extra_categories: Array[BlockCategory] = []):
-	reset_picker()
-
-	var blocks := CategoryFactory.get_general_blocks() + extra_blocks
-	var block_categories := CategoryFactory.get_categories(blocks, extra_categories)
-
-	for _category in block_categories:
-		var category: BlockCategory = _category as BlockCategory
-
+	for category in block_categories:
 		var block_category_button: BlockCategoryButton = BlockCategoryButtonScene.instantiate()
 		block_category_button.category = category
 		block_category_button.selected.connect(_category_selected)
@@ -71,7 +68,15 @@ func init_picker(extra_blocks: Array[BlockDefinition] = [], extra_categories: Ar
 
 		_block_list.add_child(block_category_display)
 
-		_block_scroll.scroll_vertical = 0
+
+func _reset_picker():
+	for node in _category_list.get_children():
+		_category_list.remove_child(node)
+		node.queue_free()
+
+	for node in _block_list.get_children():
+		_block_list.remove_child(node)
+		node.queue_free()
 
 
 func scroll_to(y: float):
@@ -90,19 +95,3 @@ func _category_selected(category: BlockCategory):
 
 func set_collapsed(collapsed: bool):
 	_widget_container.visible = not collapsed
-
-
-func reload_variables(variables: Array[VariableDefinition]):
-	if _variable_category_display:
-		for c in _variable_category_display.variable_blocks.get_children():
-			c.queue_free()
-
-		var i := 1
-		for block in Util.instantiate_variable_blocks(variables):
-			_variable_category_display.variable_blocks.add_child(block)
-			block.drag_started.connect(func(block: Block): block_picked.emit(block))
-			if i % 2 == 0:
-				var spacer := Control.new()
-				spacer.custom_minimum_size.y = 12
-				_variable_category_display.variable_blocks.add_child(spacer)
-			i += 1

--- a/addons/block_code/ui/title_bar/title_bar.gd
+++ b/addons/block_code/ui/title_bar/title_bar.gd
@@ -5,6 +5,8 @@ const BlockCodePlugin = preload("res://addons/block_code/block_code_plugin.gd")
 
 signal node_name_changed(node_name: String)
 
+@onready var _context := BlockEditorContext.get_default()
+
 @onready var _block_code_icon = load("res://addons/block_code/block_code_node/block_code_node.svg") as Texture2D
 @onready var _editor_inspector: EditorInspector = EditorInterface.get_inspector()
 @onready var _editor_selection: EditorSelection = EditorInterface.get_selection()
@@ -12,17 +14,11 @@ signal node_name_changed(node_name: String)
 
 
 func _ready():
+	_context.changed.connect(_on_context_changed)
 	_node_option_button.connect("item_selected", _on_node_option_button_item_selected)
 
 
-func scene_selected(scene_root: Node):
-	_update_node_option_button_items()
-	var current_block_code = _editor_inspector.get_edited_object() as BlockCode
-	if not current_block_code:
-		block_script_selected(null)
-
-
-func block_script_selected(block_script: BlockScriptSerialization):
+func _on_context_changed():
 	# TODO: We should listen for property changes in all BlockCode nodes and
 	#       their parents. As a workaround for the UI displaying stale data,
 	#       we'll crudely update the list of BlockCode nodes whenever the
@@ -30,7 +26,7 @@ func block_script_selected(block_script: BlockScriptSerialization):
 
 	_update_node_option_button_items()
 
-	var select_index = _get_block_script_index(block_script)
+	var select_index = _get_block_script_index(_context.block_script)
 	if _node_option_button.selected != select_index:
 		_node_option_button.select(select_index)
 
@@ -52,6 +48,8 @@ func _update_node_option_button_items():
 		_node_option_button.add_item(node_label)
 		_node_option_button.set_item_icon(node_item_index, _block_code_icon)
 		_node_option_button.set_item_metadata(node_item_index, block_code)
+
+	_node_option_button.disabled = _node_option_button.item_count == 0
 
 
 func _get_block_script_index(block_script: BlockScriptSerialization) -> int:

--- a/addons/block_code/ui/util.gd
+++ b/addons/block_code/ui/util.gd
@@ -1,48 +1,5 @@
 extends Object
 
-const BlockDefinition = preload("res://addons/block_code/code_generation/block_definition.gd")
-const BlocksCatalog = preload("res://addons/block_code/code_generation/blocks_catalog.gd")
-const Types = preload("res://addons/block_code/types/types.gd")
-const Constants = preload("res://addons/block_code/ui/constants.gd")
-const VariableDefinition = preload("res://addons/block_code/code_generation/variable_definition.gd")
-
-const SCENE_PER_TYPE = {
-	Types.BlockType.ENTRY: preload("res://addons/block_code/ui/blocks/entry_block/entry_block.tscn"),
-	Types.BlockType.STATEMENT: preload("res://addons/block_code/ui/blocks/statement_block/statement_block.tscn"),
-	Types.BlockType.VALUE: preload("res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn"),
-	Types.BlockType.CONTROL: preload("res://addons/block_code/ui/blocks/control_block/control_block.tscn"),
-}
-
-
-static func get_category_color(category: String) -> Color:
-	var category_props: Dictionary = Constants.BUILTIN_CATEGORIES_PROPS.get(category, {})
-	return category_props.get("color", Color.SLATE_GRAY)
-
-
-static func instantiate_block(block_definition: BlockDefinition) -> Block:
-	if block_definition == null:
-		push_error("Cannot construct block from null block definition.")
-		return null
-
-	var scene = SCENE_PER_TYPE.get(block_definition.type)
-	if scene == null:
-		push_error("Cannot instantiate Block from type %s" % block_definition.type)
-		return null
-
-	var block = scene.instantiate()
-	block.definition = block_definition
-	return block
-
-
-static func instantiate_variable_blocks(variables: Array[VariableDefinition]) -> Array[Block]:
-	var blocks: Array[Block] = []
-	for block_definition in BlocksCatalog.get_variable_block_definitions(variables):
-		var block = instantiate_block(block_definition)
-		block.color = get_category_color(block_definition.category)
-		blocks.append(block)
-
-	return blocks
-
 
 ## Polyfill of Node.is_part_of_edited_scene(), available to GDScript in Godot 4.3+.
 static func node_is_part_of_edited_scene(node: Node) -> bool:

--- a/tests/test_category_factory.gd
+++ b/tests/test_category_factory.gd
@@ -8,13 +8,19 @@ const BlocksCatalog = preload("res://addons/block_code/code_generation/blocks_ca
 var block_script: BlockScriptSerialization
 
 
+func assert_set_eq(set_a: Array, set_b: Array, text: String = ""):
+	var set_a_sorted := set_a.duplicate()
+	var set_b_sorted := set_b.duplicate()
+	set_a_sorted.sort()
+	set_b_sorted.sort()
+	assert_eq(set_a_sorted, set_b_sorted, text)
+
+
 func get_category_names(categories: Array[BlockCategory]) -> Array[String]:
-	var categories_sorted: Array[BlockCategory]
-	categories_sorted.assign(categories)
-	categories_sorted.sort_custom(BlockCategory.sort_by_order)
-	var result: Array[String]
-	result.assign(categories_sorted.map(func(category): return category.name))
-	return result
+	var category_names: Array[String]
+	category_names.assign(categories.map(func(category): return category.name))
+	category_names.sort()
+	return category_names
 
 
 func get_class_category_names(_class_name: String) -> Array[String]:
@@ -28,27 +34,27 @@ func before_each():
 	block_script.initialize()
 
 
+const default_category_names = [
+	"Communication | Groups",
+	"Communication | Methods",
+	"Graphics | Viewport",
+	"Input",
+	"Lifecycle",
+	"Log",
+	"Logic | Boolean",
+	"Logic | Comparison",
+	"Logic | Conditionals",
+	"Loops",
+	"Math",
+	"Sounds",
+	"Variables",
+]
+
+
 func test_general_category_names():
 	var blocks: Array[BlockDefinition] = block_script.get_available_blocks()
 	var names: Array[String] = get_category_names(block_script.get_available_categories())
-	assert_eq(
-		names,
-		[
-			"Lifecycle",
-			"Graphics | Viewport",
-			"Sounds",
-			"Input",
-			"Communication | Methods",
-			"Communication | Groups",
-			"Loops",
-			"Logic | Conditionals",
-			"Logic | Comparison",
-			"Logic | Boolean",
-			"Variables",
-			"Math",
-			"Log",
-		]
-	)
+	assert_set_eq(names, default_category_names)
 
 
 const class_category_names = [
@@ -60,7 +66,7 @@ const class_category_names = [
 
 
 func test_inherited_category_names(params = use_parameters(class_category_names)):
-	assert_eq(get_class_category_names(params[0]), params[1])
+	assert_set_eq(get_class_category_names(params[0]), default_category_names + params[1])
 
 
 func test_unique_block_names():

--- a/tests/test_code_generation.gd
+++ b/tests/test_code_generation.gd
@@ -9,6 +9,7 @@ const BlockDefinition = preload("res://addons/block_code/code_generation/block_d
 const BlocksCatalog = preload("res://addons/block_code/code_generation/blocks_catalog.gd")
 
 var general_blocks: Dictionary
+var block_script: BlockScriptSerialization
 
 
 func build_block_map(block_map: Dictionary, blocks: Array[BlockDefinition]):
@@ -24,7 +25,9 @@ func free_block_map(block_map: Dictionary):
 
 
 func before_each():
-	build_block_map(general_blocks, CategoryFactory.get_general_blocks())
+	block_script = BlockScriptSerialization.new()
+	block_script.initialize()
+	build_block_map(general_blocks, block_script.get_available_blocks())
 
 
 func after_each():


### PR DESCRIPTION
We need a way to customize blocks depending on the node being edited. To address this, I found myself doing a few things:

- Replaced the big, global `CategoryFactory` with a `BlockBuilder` that is instantiated for the currently selected block script. I don't super like how I did this - in particular that both picker.gd and block_canvas.gd instantiate their own (redundant) `BlockBuilder` instances. Getting it right means further adjusting how data flows between these things.
- (I don't actually like the name `BlockBuilder` since it implies we're using [the Builder pattern](https://en.wikipedia.org/wiki/Builder_pattern), which was my original intent but it is not what it is doing. Probably just `BlockFactory` would make sense).
- But the big thing this gives us is `BlockBuilder` has a single function which generates a single big list of blocks, including variable blocks. It knows what node our block script belongs to. I think that is a reasonable thing for it to know, but we could specify some rules here like "don't do anything that makes it impossible to move a block script to another node."
- With that said, I broke the variables category here - categories in general are a _disaster_ in this branch - as well as 
`setup_custom_blocks()` in node scripts.
- I added a concept of extension scripts for block definitions. This is an extra GDScript property, so you can optionally attach a plain old Object with some functions defined. I did this for `animationplayer_play.tres`. We should take the time to actually specify an API here, and perhaps a `BlockExtensionScript` base class just to be sure. For now, I just have `animationplayer_play.gd` with `func get_defaults_for_node(context_node: Node)`. It's a little broken still.
- I broke a bunch of tests :(

https://phabricator.endlessm.com/T35564