### PR TITLE
Fix signal name for area2d_on_exited block

### DIFF
--- a/addons/block_code/blocks/communication/area2d_on_exited.tres
+++ b/addons/block_code/blocks/communication/area2d_on_exited.tres
@@ -14,5 +14,5 @@ display_template = "On [body: OBJECT] exited"
 code_template = "func _on_body_exited(body: Node2D):
 "
 defaults = {}
-signal_name = "body_entered"
+signal_name = "body_exited"
 scope = ""


### PR DESCRIPTION
The signal needs to be body_exited.