### PR TITLE
Remove _exit_tree methods from Simple nodes

### DIFF
--- a/addons/block_code/simple_nodes/simple_character/simple_character.gd
+++ b/addons/block_code/simple_nodes/simple_character/simple_character.gd
@@ -72,16 +72,6 @@ func simple_setup():
 	_texture_updated()
 
 
-func _exit_tree():
-	if collision:
-		collision.queue_free()
-		collision = null
-
-	if sprite:
-		sprite.queue_free()
-		sprite = null
-
-
 func get_custom_class():
 	return "SimpleCharacter"
 

--- a/addons/block_code/simple_nodes/simple_scoring/simple_scoring.gd
+++ b/addons/block_code/simple_nodes/simple_scoring/simple_scoring.gd
@@ -63,12 +63,6 @@ func simple_setup():
 	add_child(right_label)
 
 
-func _exit_tree():
-	for label in _score_labels.values():
-		label.queue_free()
-	_score_labels.clear()
-
-
 func get_custom_class():
 	return "SimpleScoring"
 


### PR DESCRIPTION
There is no need for this cleanup because from docs: [1]
> If the node has children, its _exit_tree callback will be called last,
> after all its children have left the tree.

Also because: [2]
> when a node is freed with Object.free or queue_free, it will also free
> all its children.

Further, this removes the sprite and collision while in the editor when the user switches to another scene tab #213.

[1] https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-private-method-exit-tree
[2] https://docs.godotengine.org/en/stable/classes/class_node.html#description

Fixes #213