### PR TITLE
SimpleCharacter: Don't impose a collision shape

### DIFF
--- a/addons/block_code/simple_nodes/simple_character/simple_character.gd
+++ b/addons/block_code/simple_nodes/simple_character/simple_character.gd
@@ -72,16 +72,6 @@ func simple_setup():
 	_texture_updated()
 
 
-func _exit_tree():
-	if collision:
-		collision.queue_free()
-		collision = null
-
-	if sprite:
-		sprite.queue_free()
-		sprite = null
-
-
 func get_custom_class():
 	return "SimpleCharacter"
 

--- a/addons/block_code/simple_nodes/simple_character/simple_character.gd
+++ b/addons/block_code/simple_nodes/simple_character/simple_character.gd
@@ -6,6 +6,8 @@ const BlockDefinition = preload("res://addons/block_code/code_generation/block_d
 const BlocksCatalog = preload("res://addons/block_code/code_generation/blocks_catalog.gd")
 const Types = preload("res://addons/block_code/types/types.gd")
 
+## A texture can be provided for simple setup. If provided, the character will have a collision box
+## that matches the size of the texture.
 @export var texture: Texture2D:
 	set = _set_texture
 
@@ -44,8 +46,28 @@ func _set_texture(new_texture):
 
 
 func _texture_updated():
+	if not texture:
+		if sprite:
+			sprite.queue_free()
+			sprite = null
+		if collision:
+			collision.queue_free()
+			collision = null
+		return
+
+	if not sprite:
+		sprite = Sprite2D.new()
+		sprite.name = &"Sprite2D"
+		add_child(sprite)
+
+	if not collision:
+		collision = CollisionShape2D.new()
+		collision.name = &"CollisionShape2D"
+		collision.shape = RectangleShape2D.new()
+		add_child(collision)
+
 	sprite.texture = texture
-	collision.shape.size = Vector2(100, 100) if texture == null else texture.get_size()
+	collision.shape.size = texture.get_size()
 
 
 ## Nodes in the "affected_by_gravity" group will receive gravity changes:
@@ -59,16 +81,6 @@ func _ready():
 
 func simple_setup():
 	add_to_group("affected_by_gravity", true)
-
-	sprite = Sprite2D.new()
-	sprite.name = &"Sprite2D"
-	add_child(sprite)
-
-	collision = CollisionShape2D.new()
-	collision.name = &"CollisionShape2D"
-	collision.shape = RectangleShape2D.new()
-	add_child(collision)
-
 	_texture_updated()
 
 

--- a/addons/block_code/simple_nodes/simple_scoring/simple_scoring.gd
+++ b/addons/block_code/simple_nodes/simple_scoring/simple_scoring.gd
@@ -63,12 +63,6 @@ func simple_setup():
 	add_child(right_label)
 
 
-func _exit_tree():
-	for label in _score_labels.values():
-		label.queue_free()
-	_score_labels.clear()
-
-
 func get_custom_class():
 	return "SimpleScoring"
 


### PR DESCRIPTION
Change the logic so there is no fallback 100x100 collision shape if a
texture is not provided. This way the user can customize their character
by adding their own sprites and collision shapes as node children. The
simple setup of passing a texture is still maintained. Although it has
been found to be inflexible (can't resize the texture from the canvas,
can't change the shape of the collision).

Addresses https://github.com/endlessm/godot-block-coding/issues/215