### PR TITLE
ParameterInput: Don't snap blocks for option inputs

### DIFF
--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
@@ -11,7 +11,8 @@ signal modified
 
 @export var variant_type: Variant.Type = TYPE_STRING
 @export var block_type: Types.BlockType = Types.BlockType.VALUE
-var option: bool = false
+var option: bool = false:
+	set = _set_option
 
 @onready var _panel := %Panel
 @onready var snap_point := %SnapPoint
@@ -103,11 +104,22 @@ func _set_placeholder(new_placeholder: String) -> void:
 	_line_edit.placeholder_text = placeholder
 
 
+func _set_option(value: bool) -> void:
+	option = value
+
+	if not is_node_ready():
+		return
+
+	# If options are being provided, you can't snap blocks.
+	snap_point.visible = not option
+
+
 func _ready():
 	var stylebox = _panel.get_theme_stylebox("panel")
 	stylebox.bg_color = Color.WHITE
 
 	_set_placeholder(placeholder)
+	_set_option(option)
 
 	snap_point.block_type = block_type
 	snap_point.variant_type = variant_type


### PR DESCRIPTION
Option inputs only allow selecting from a set of predefined OptionData values. Prevent trying to snap a block to an option input by making the snap point invisible.

Fixes: #167

Note that this doesn't fix the more general problem that the comparison block can't handle vectors, but I think it fixes the more important issue that you could snap a block into options.