### PR TITLE
Improve keyboard accessibility in create_variable_dialog

### DIFF
--- a/addons/block_code/ui/picker/categories/variable_category/create_variable_button.gd
+++ b/addons/block_code/ui/picker/categories/variable_category/create_variable_button.gd
@@ -7,7 +7,7 @@ signal create_variable(var_name: String, var_type: String)
 
 
 func _on_create_button_pressed():
-	_create_variable_dialog.visible = true
+	_create_variable_dialog.popup()
 
 
 func _on_create_variable_dialog_create_variable(var_name, var_type):

--- a/addons/block_code/ui/picker/categories/variable_category/create_variable_dialog.gd
+++ b/addons/block_code/ui/picker/categories/variable_category/create_variable_dialog.gd
@@ -14,16 +14,20 @@ const available_types = ["STRING", "BOOL", "INT", "FLOAT", "VECTOR2", "COLOR"]
 
 func _ready():
 	_type_option.clear()
+	_type_option.focus_next = get_cancel_button().get_path()
+	get_cancel_button().focus_previous = _type_option.get_path()
+	get_ok_button().focus_next = _variable_input.get_path()
+	_variable_input.focus_previous = get_ok_button().get_path()
 
 	for type in available_types:
 		_type_option.add_item(type)
 
-	check_errors(_variable_input.text)
+	_clear()
 
 
 func _clear():
 	_variable_input.text = ""
-	check_errors(_variable_input.text)
+	get_ok_button().disabled = check_errors(_variable_input.text)
 	_type_option.select(0)
 
 
@@ -93,10 +97,25 @@ func check_errors(new_var_name: String) -> bool:
 
 
 func _on_confirmed():
-	if not check_errors(_variable_input.text):
-		create_variable.emit(_variable_input.text, _type_option.get_item_text(_type_option.selected))
+	if check_errors(_variable_input.text):
+		return
+
+	create_variable.emit(_variable_input.text, _type_option.get_item_text(_type_option.selected))
+	hide()
 	_clear()
 
 
 func _on_canceled():
 	_clear()
+
+
+func _on_about_to_popup() -> void:
+	_variable_input.grab_focus()
+
+
+func _on_focus_entered() -> void:
+	_variable_input.grab_focus()
+
+
+func _on_variable_input_text_submitted(new_text: String) -> void:
+	_on_confirmed()

--- a/addons/block_code/ui/picker/categories/variable_category/create_variable_dialog.tscn
+++ b/addons/block_code/ui/picker/categories/variable_category/create_variable_dialog.tscn
@@ -8,6 +8,7 @@ initial_position = 1
 size = Vector2i(300, 183)
 visible = true
 ok_button_text = "Create"
+dialog_hide_on_ok = false
 script = ExtResource("1_b52me")
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
@@ -27,6 +28,8 @@ text = "Name "
 [node name="VariableInput" type="LineEdit" parent="VBoxContainer/GridContainer"]
 unique_name_in_owner = true
 layout_mode = 2
+focus_neighbor_bottom = NodePath("../TypeOption")
+focus_next = NodePath("../TypeOption")
 
 [node name="Label2" type="Label" parent="VBoxContainer/GridContainer"]
 layout_mode = 2
@@ -36,10 +39,11 @@ text = "Type "
 unique_name_in_owner = true
 layout_mode = 2
 size_flags_horizontal = 3
-item_count = 6
+focus_neighbor_top = NodePath("../VariableInput")
+focus_previous = NodePath("../VariableInput")
 selected = 0
+item_count = 6
 popup/item_0/text = "STRING"
-popup/item_0/id = 0
 popup/item_1/text = "BOOL"
 popup/item_1/id = 1
 popup/item_2/text = "INT"
@@ -63,6 +67,9 @@ layout_mode = 2
 theme_override_constants/line_separation = 4
 fit_content = true
 
+[connection signal="about_to_popup" from="." to="." method="_on_about_to_popup"]
 [connection signal="canceled" from="." to="." method="_on_canceled"]
 [connection signal="confirmed" from="." to="." method="_on_confirmed"]
+[connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
 [connection signal="text_changed" from="VBoxContainer/GridContainer/VariableInput" to="." method="_on_variable_input_text_changed"]
+[connection signal="text_submitted" from="VBoxContainer/GridContainer/VariableInput" to="." method="_on_variable_input_text_submitted"]


### PR DESCRIPTION
When the dialog is focused, we need to focus the custom dialog's own controls instead of the dialog's buttons. In addition, set focus_next and focus_previous properties so focus flows between child widgets and the dialog's ok / cancel buttons. The focus loops around within the dialog, as is conventional with other dialogs in the Godot editor.