### PR TITLE
Add breakpoint block

### DIFF
--- a/addons/block_code/blocks/log/breakpoint.tres
+++ b/addons/block_code/blocks/log/breakpoint.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3 uid="uid://bddy0d4xdv20c"]
+
+[ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_xva04"]
+
+[resource]
+script = ExtResource("1_xva04")
+name = &"breakpoint"
+target_node_class = ""
+description = "Pause execution and show the current line of code in the debugger."
+category = "Log"
+type = 2
+variant_type = 0
+display_template = "Breakpoint"
+code_template = "breakpoint"
+defaults = {}
+signal_name = ""
+scope = ""


### PR DESCRIPTION
An example of this in use:

![Screenshot From 2024-09-19 12-02-53](https://github.com/user-attachments/assets/a9611bb3-8966-4099-9beb-7fe81feb816c)

We can't see the generated code in the debugger (or at least I don't know how to reach it), but we can inspect local variables and the Godot objects they are referencing, which can be fairly useful.