### PR TITLE
Allow dragging nodes to block canvas

### DIFF
--- a/addons/block_code/block_code_plugin.gd
+++ b/addons/block_code/block_code_plugin.gd
@@ -13,7 +13,6 @@ const BlockInspectorPlugin := preload("res://addons/block_code/inspector_plugin/
 var block_inspector_plugin: BlockInspectorPlugin
 
 var editor_inspector: EditorInspector
-var editor_selection: EditorSelection
 
 var _selected_block_code: BlockCode
 
@@ -34,7 +33,6 @@ func _enter_tree():
 	Types.init_cast_graph()
 
 	editor_inspector = EditorInterface.get_inspector()
-	editor_selection = EditorInterface.get_selection()
 
 	main_panel = MainPanelScene.instantiate()
 	main_panel.script_window_requested.connect(script_window_requested)
@@ -100,31 +98,14 @@ func _ready():
 
 func _on_editor_inspector_edited_object_changed():
 	var edited_object = editor_inspector.get_edited_object()
-	#var edited_node = edited_object as Node
-	var selected_nodes = editor_selection.get_selected_nodes()
-
-	if edited_object is BlockCode:
+	var block_code_node = edited_object as BlockCode
+	if block_code_node:
+		# If a block code node was explicitly selected, activate the
+		# Block Code panel.
 		make_bottom_panel_item_visible(main_panel)
-
-	if edited_object is BlockCode and selected_nodes.size() == 1 and edited_object.owner and edited_object != _selected_block_code:
-		# If a BlockCode node is being edited, and it was explicitly selected
-		# (as opposed to edited in the Inspector alone), select its parent node
-		# as well. This provides a clearer indication of what is being edited.
-		# Changing the selection will cause edited_object_changed to fire again,
-		# so we will return early to avoid duplicate work.
-		var parent_node = edited_object.get_parent()
-		if parent_node:
-			editor_selection.add_node.call_deferred(parent_node)
-		return
-
-	if edited_object and edited_object.get_class() == "MultiNodeEdit":
-		# If multiple nodes are shown in the inspector, we will find the first
-		# BlockCode node in the list of selected nodes and use that. This
-		# occurs when the user selects multiple items in the Scene panel, or
-		# when we select the parent of a BlockCode node.
-		edited_object = selected_nodes.filter(func(node): return node is BlockCode).pop_front()
-
-	var block_code_node = list_block_code_nodes_for_node(edited_object as Node).pop_front()
+	else:
+		# Find the first block code child.
+		block_code_node = list_block_code_nodes_for_node(edited_object as Node).pop_front()
 	select_block_code_node(block_code_node)
 
 

--- a/addons/block_code/blocks/communication/get_node.gd
+++ b/addons/block_code/blocks/communication/get_node.gd
@@ -1,0 +1,33 @@
+@tool
+extends BlockExtension
+
+const OptionData = preload("res://addons/block_code/code_generation/option_data.gd")
+const Util = preload("res://addons/block_code/ui/util.gd")
+
+
+func _find_paths(paths: Array[NodePath], node: Node, path_root: Node, block_parent: Node):
+	# Add any non-BlockCode nodes that aren't the parent of the current
+	# BlockCode node.
+	if not node is BlockCode:
+		var node_path: NodePath = Util.node_scene_path(node, block_parent, path_root)
+		if not node_path in [^"", ^"."]:
+			paths.append(node_path)
+
+	for child in node.get_children():
+		_find_paths(paths, child, path_root, block_parent)
+
+
+func get_defaults_for_node(context_node: Node) -> Dictionary:
+	# The default paths are only needed in the editor.
+	if not Engine.is_editor_hint():
+		return {}
+
+	var scene_root: Node = EditorInterface.get_edited_scene_root()
+	var path_root: Node = scene_root.get_parent()
+	var paths: Array[NodePath]
+	_find_paths(paths, scene_root, path_root, context_node)
+
+	if not paths:
+		return {}
+
+	return {"path": OptionData.new(paths)}

--- a/addons/block_code/blocks/communication/get_node.tres
+++ b/addons/block_code/blocks/communication/get_node.tres
@@ -1,0 +1,27 @@
+[gd_resource type="Resource" load_steps=5 format=3 uid="uid://canpdkahokjqs"]
+
+[ext_resource type="Script" path="res://addons/block_code/code_generation/option_data.gd" id="1_bk47y"]
+[ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_d60g7"]
+[ext_resource type="Script" path="res://addons/block_code/blocks/communication/get_node.gd" id="1_we5wl"]
+
+[sub_resource type="Resource" id="Resource_esr4a"]
+script = ExtResource("1_bk47y")
+selected = 0
+items = []
+
+[resource]
+script = ExtResource("1_d60g7")
+name = &"get_node"
+target_node_class = ""
+description = "Get the node at the given path"
+category = "Communication | Nodes"
+type = 3
+variant_type = 24
+display_template = "{path: NIL}"
+code_template = "get_node(\"{path}\")"
+defaults = {
+"path": SubResource("Resource_esr4a")
+}
+signal_name = ""
+scope = ""
+extension_script = ExtResource("1_we5wl")

--- a/addons/block_code/ui/block_canvas/block_canvas.tscn
+++ b/addons/block_code/ui/block_canvas/block_canvas.tscn
@@ -15,10 +15,12 @@ script = ExtResource("1_tk8h2")
 
 [node name="Panel" type="Panel" parent="."]
 layout_mode = 2
+mouse_filter = 2
 
 [node name="WindowContainer" type="Control" parent="."]
 clip_contents = true
 layout_mode = 2
+mouse_filter = 2
 
 [node name="Window" type="Control" parent="WindowContainer"]
 unique_name_in_owner = true

--- a/addons/block_code/ui/constants.gd
+++ b/addons/block_code/ui/constants.gd
@@ -81,6 +81,11 @@ const BUILTIN_CATEGORIES_PROPS: Dictionary = {
 		"color": Color("4b7bec"),
 		"order": 110,
 	},
+	"Communication | Nodes":
+	{
+		"color": Color("4b7bec"),
+		"order": 115,
+	},
 	"Communication | Groups":
 	{
 		"color": Color("4b7bec"),

--- a/addons/block_code/ui/main_panel.gd
+++ b/addons/block_code/ui/main_panel.gd
@@ -217,7 +217,7 @@ func _on_block_canvas_add_block_code():
 
 	undo_redo.add_do_method(edited_node, "add_child", block_code, true)
 	undo_redo.add_do_property(block_code, "owner", scene_root)
-	undo_redo.add_do_method(self, "_select_block_code_node", edited_node)
+	undo_redo.add_do_property(_context, "block_code_node", block_code)
 	undo_redo.add_do_reference(block_code)
 	undo_redo.add_undo_method(edited_node, "remove_child", block_code)
 	undo_redo.add_undo_property(block_code, "owner", null)
@@ -246,24 +246,9 @@ func _on_block_canvas_replace_block_code():
 	#        Ideally this should fix itself in a future version of Godot.
 
 	undo_redo.add_do_method(scene_root, "set_editable_instance", edited_node, true)
-	undo_redo.add_do_method(self, "_select_block_code_node", edited_node)
 	undo_redo.add_undo_method(scene_root, "set_editable_instance", edited_node, false)
 
 	undo_redo.commit_action()
-
-
-func _select_block_code_node(edited_node: Node):
-	var block_code_nodes = BlockCodePlugin.list_block_code_nodes_for_node(edited_node)
-	if block_code_nodes.size() > 0:
-		_set_selection([block_code_nodes.pop_front()])
-	else:
-		_set_selection([edited_node])
-
-
-func _set_selection(nodes: Array[Node]):
-	EditorInterface.get_selection().clear()
-	for node in nodes:
-		EditorInterface.get_selection().add_node(node)
 
 
 func _create_variable(variable: VariableDefinition):

--- a/addons/block_code/ui/title_bar/title_bar.gd
+++ b/addons/block_code/ui/title_bar/title_bar.gd
@@ -9,7 +9,6 @@ signal node_name_changed(node_name: String)
 
 @onready var _block_code_icon = load("res://addons/block_code/block_code_node/block_code_node.svg") as Texture2D
 @onready var _editor_inspector: EditorInspector = EditorInterface.get_inspector()
-@onready var _editor_selection: EditorSelection = EditorInterface.get_selection()
 @onready var _node_option_button: OptionButton = %NodeOptionButton
 
 
@@ -62,8 +61,4 @@ func _get_block_script_index(block_script: BlockScriptSerialization) -> int:
 
 func _on_node_option_button_item_selected(index):
 	var block_code_node = _node_option_button.get_item_metadata(index) as BlockCode
-	var parent_node = block_code_node.get_parent() as Node
-	_editor_selection.clear()
-	_editor_selection.add_node(block_code_node)
-	if parent_node:
-		_editor_selection.add_node(parent_node)
+	_context.block_code_node = block_code_node

--- a/addons/block_code/ui/util.gd
+++ b/addons/block_code/ui/util.gd
@@ -12,3 +12,38 @@ static func node_is_part_of_edited_scene(node: Node) -> bool:
 
 	var edited_scene_parent := tree.edited_scene_root.get_parent()
 	return edited_scene_parent and edited_scene_parent.is_ancestor_of(node)
+
+
+## Get the path from [param reference] to [param node] within a scene.
+##
+## Returns the path from [param reference] to [param node] without referencing
+## parent nodes. If [param node] is [param reference] or a child of it in the
+## scene tree, a relative path is returned. If [param node] is an ancestor of
+## [param reference] in the scene tree, an absolute path using [param
+## path_root] is returned.
+## [br]
+## Both [param node] and [param reference] must be ancestors of [param
+## path_root]. If [param path_root] is [constant null]
+## [method EditorInterface.get_edited_scene_root().get_parent] is used.
+static func node_scene_path(node: Node, reference: Node, path_root: Node = null) -> NodePath:
+	if path_root == null:
+		path_root = EditorInterface.get_edited_scene_root().get_parent()
+
+	if not path_root.is_ancestor_of(node):
+		push_error("Node %s is not an ancestor of %s" % [path_root, node])
+		return NodePath()
+	if not path_root.is_ancestor_of(reference):
+		push_error("Node %s is not an ancestor of %s" % [path_root, reference])
+		return NodePath()
+
+	if node.unique_name_in_owner:
+		# With unique_name_in_owner, just use the % prefixed name.
+		return NodePath("%%%s" % node.name)
+	elif node.is_ancestor_of(reference):
+		# If the node is an ancestor of the reference, it would begin
+		# with an ugly ../. Use an absolute path where /root is the
+		# path_root node.
+		return NodePath("/root/%s" % path_root.get_path_to(node))
+	else:
+		# The node is reference or a child of it. Use a relative path.
+		return reference.get_path_to(node)

--- a/tests/test_category_factory.gd
+++ b/tests/test_category_factory.gd
@@ -37,6 +37,7 @@ func before_each():
 const default_category_names = [
 	"Communication | Groups",
 	"Communication | Methods",
+	"Communication | Nodes",
 	"Graphics | Viewport",
 	"Input",
 	"Lifecycle",


### PR DESCRIPTION
In order to call methods on other nodes, you need a reference to the node. This adds a new `get_node` block definition that has all the other nodes provided as options. It also adds a method to drag a node from the scene tree dock and set the node's path in a `get_node` block automatically.

Unfortunately, in order to make the drag action usable, I had to drop the multi-select feature that automatically activates the block node's parent in the scene editor. I searched long for a way to do that without selecting the node, but it doesn't appear that there's a way to do it.

https://phabricator.endlessm.com/T35648