### PR TITLE
Cleanup dependencies

### DIFF
--- a/addons/block_code/ui/blocks/control_block/control_block.gd
+++ b/addons/block_code/ui/blocks/control_block/control_block.gd
@@ -3,9 +3,6 @@ class_name ControlBlock
 extends Block
 
 const Constants = preload("res://addons/block_code/ui/constants.gd")
-const DragDropArea = preload("res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.gd")
-const DragDropAreaScene = preload("res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn")
-const Gutter = preload("res://addons/block_code/ui/blocks/utilities/background/gutter.gd")
 
 
 func _ready():

--- a/addons/block_code/ui/blocks/statement_block/statement_block.gd
+++ b/addons/block_code/ui/blocks/statement_block/statement_block.gd
@@ -2,10 +2,6 @@
 class_name StatementBlock
 extends Block
 
-const ParameterInput = preload("res://addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd")
-const ParameterInputScene = preload("res://addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn")
-const ParameterOutput = preload("res://addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.gd")
-const ParameterOutputScene = preload("res://addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.tscn")
 const Types = preload("res://addons/block_code/types/types.gd")
 
 @onready var _background := %Background

--- a/addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.gd
@@ -3,7 +3,6 @@ extends MarginContainer
 
 const Types = preload("res://addons/block_code/types/types.gd")
 const ParameterBlock = preload("res://addons/block_code/ui/blocks/parameter_block/parameter_block.gd")
-const ParameterBlockScene = preload("res://addons/block_code/ui/blocks/parameter_block/parameter_block.tscn")
 
 var block: Block
 var parameter_name: String

--- a/addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.tscn
+++ b/addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.tscn
@@ -33,6 +33,5 @@ layout_mode = 2
 block_type = 0
 variant_type = 4
 
-[connection signal="child_exiting_tree" from="." to="SnapPoint" method="_on_parameter_output_child_exiting_tree"]
 [connection signal="snapped_block_changed" from="SnapPoint" to="." method="_on_snap_point_snapped_block_changed"]
 [connection signal="snapped_block_removed" from="SnapPoint" to="." method="_on_snap_point_snapped_block_removed"]


### PR DESCRIPTION
Found these while chasing the following error:

```
ERROR: res://addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.tscn:30 - Parse Error: [ext_resource] referenced non-existent resource at: res://addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn
   at: _parse_ext_resource (scene/resources/resource_format_text.cpp:159)
```

The message is deeply unhelpful, but it's caused by a circular dependency between classes.