### PR TITLE
block: Show tooltips for blocks

### DIFF
--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -189,6 +189,10 @@ func _to_string():
 	return "<{block_class}:{block_name}#{rid}>".format({"block_name": definition.name if definition else "", "block_class": get_block_class(), "rid": get_instance_id()})
 
 
+func _get_tooltip(at_position: Vector2) -> String:
+	return definition.description if definition else ""
+
+
 func _make_custom_tooltip(for_text) -> Control:
 	var tooltip = preload("res://addons/block_code/ui/tooltip/tooltip.tscn").instantiate()
 	tooltip.text = for_text


### PR DESCRIPTION
Prior to commit 7a6fe1329cb2d2b746a08fedb3fb6288cc0e6bba, instantiate_block() would set the new Block's tooltip_text property to the BlockDefinition's description.

Since that commit, we just set a definition property on the Block to the BlockDefinition.

Implement Control._get_tooltip(), returning BlockDefinition.definition, which restores tooltips to blocks.

https://phabricator.endlessm.com/T35645