### PR TITLE
ParameterInput: Ignore mouse events when not visible

### DIFF
--- a/addons/block_code/ui/blocks/control_block/control_block.gd
+++ b/addons/block_code/ui/blocks/control_block/control_block.gd
@@ -17,7 +17,7 @@ func _ready():
 	%SnapGutter.custom_minimum_size.x = Constants.CONTROL_MARGIN
 
 
-func _on_drag_drop_area_mouse_down():
+func _on_drag_drop_area_drag_started() -> void:
 	_drag_started()
 
 

--- a/addons/block_code/ui/blocks/control_block/control_block.tscn
+++ b/addons/block_code/ui/blocks/control_block/control_block.tscn
@@ -2,8 +2,8 @@
 
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/control_block/control_block.gd" id="1_2hbir"]
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/utilities/background/gutter.gd" id="2_6o8pf"]
-[ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="2_lpu3c"]
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/utilities/background/background.gd" id="2_tx0qr"]
+[ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="3_21e8n"]
 [ext_resource type="PackedScene" uid="uid://b1oge52xhjqnu" path="res://addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn" id="3_nhryi"]
 [ext_resource type="PackedScene" uid="uid://b1xvp3u11h41s" path="res://addons/block_code/ui/blocks/utilities/template_editor/template_editor.tscn" id="4_6uktl"]
 
@@ -48,8 +48,9 @@ script = ExtResource("2_tx0qr")
 color = Color(1, 1, 1, 1)
 shift_bottom = 20.0
 
-[node name="DragDropArea" parent="VBoxContainer/MarginContainer/Rows/Row" instance=ExtResource("2_lpu3c")]
+[node name="DragDropArea" parent="VBoxContainer/MarginContainer/Rows/Row" instance=ExtResource("3_21e8n")]
 layout_mode = 2
+mouse_default_cursor_shape = 2
 
 [node name="RowHBoxContainer" type="MarginContainer" parent="VBoxContainer/MarginContainer/Rows/Row"]
 layout_mode = 2
@@ -95,4 +96,4 @@ shift_top = 20.0
 [node name="SnapPoint" parent="VBoxContainer" instance=ExtResource("3_nhryi")]
 layout_mode = 2
 
-[connection signal="mouse_down" from="VBoxContainer/MarginContainer/Rows/Row/DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]
+[connection signal="drag_started" from="VBoxContainer/MarginContainer/Rows/Row/DragDropArea" to="." method="_on_drag_drop_area_drag_started"]

--- a/addons/block_code/ui/blocks/entry_block/entry_block.tscn
+++ b/addons/block_code/ui/blocks/entry_block/entry_block.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/entry_block/entry_block.gd" id="2_3ik8h"]
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/utilities/background/background.gd" id="2_yrw8l"]
-[ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="3_v0qw8"]
+[ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="3_swkpp"]
 [ext_resource type="PackedScene" uid="uid://b1xvp3u11h41s" path="res://addons/block_code/ui/blocks/utilities/template_editor/template_editor.tscn" id="4_1gwsm"]
 [ext_resource type="PackedScene" uid="uid://b1oge52xhjqnu" path="res://addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn" id="4_yj206"]
 
@@ -37,8 +37,9 @@ script = ExtResource("2_yrw8l")
 color = Color(1, 1, 1, 1)
 show_top = false
 
-[node name="DragDropArea" parent="VBoxContainer/TopMarginContainer" instance=ExtResource("3_v0qw8")]
+[node name="DragDropArea" parent="VBoxContainer/TopMarginContainer" instance=ExtResource("3_swkpp")]
 layout_mode = 2
+mouse_default_cursor_shape = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/TopMarginContainer"]
 layout_mode = 2
@@ -55,4 +56,4 @@ layout_mode = 2
 [node name="SnapPoint" parent="VBoxContainer" instance=ExtResource("4_yj206")]
 layout_mode = 2
 
-[connection signal="mouse_down" from="VBoxContainer/TopMarginContainer/DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]
+[connection signal="drag_started" from="VBoxContainer/TopMarginContainer/DragDropArea" to="." method="_on_drag_drop_area_drag_started"]

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.gd
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.gd
@@ -30,7 +30,7 @@ func _ready():
 		_panel.add_theme_stylebox_override("panel", _panel_normal)
 
 
-func _on_drag_drop_area_mouse_down():
+func _on_drag_drop_area_drag_started() -> void:
 	_drag_started()
 
 

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=5 format=3 uid="uid://clipm2dd28jde"]
 
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/parameter_block/parameter_block.gd" id="1_0hajy"]
-[ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="2_gy5co"]
+[ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="2_0eadx"]
 [ext_resource type="PackedScene" uid="uid://b1xvp3u11h41s" path="res://addons/block_code/ui/blocks/utilities/template_editor/template_editor.tscn" id="3_shl1a"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_dbera"]
@@ -29,8 +29,9 @@ unique_name_in_owner = true
 layout_mode = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_dbera")
 
-[node name="DragDropArea" parent="." instance=ExtResource("2_gy5co")]
+[node name="DragDropArea" parent="." instance=ExtResource("2_0eadx")]
 layout_mode = 2
+mouse_default_cursor_shape = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="."]
 layout_mode = 2
@@ -47,4 +48,4 @@ theme_override_constants/margin_bottom = 8
 
 [connection signal="focus_entered" from="." to="." method="_on_focus_entered"]
 [connection signal="focus_exited" from="." to="." method="_on_focus_exited"]
-[connection signal="mouse_down" from="DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]
+[connection signal="drag_started" from="DragDropArea" to="." method="_on_drag_drop_area_drag_started"]

--- a/addons/block_code/ui/blocks/statement_block/statement_block.gd
+++ b/addons/block_code/ui/blocks/statement_block/statement_block.gd
@@ -18,7 +18,7 @@ func _ready():
 	_background.color = color
 
 
-func _on_drag_drop_area_mouse_down():
+func _on_drag_drop_area_drag_started() -> void:
 	_drag_started()
 
 

--- a/addons/block_code/ui/blocks/statement_block/statement_block.tscn
+++ b/addons/block_code/ui/blocks/statement_block/statement_block.tscn
@@ -2,8 +2,8 @@
 
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/statement_block/statement_block.gd" id="1_6wvlf"]
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/utilities/background/background.gd" id="2_lctqt"]
-[ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="2_owgdx"]
 [ext_resource type="PackedScene" uid="uid://b1oge52xhjqnu" path="res://addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn" id="3_5vaov"]
+[ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="3_mbxhq"]
 [ext_resource type="PackedScene" uid="uid://b1xvp3u11h41s" path="res://addons/block_code/ui/blocks/utilities/template_editor/template_editor.tscn" id="4_vky23"]
 
 [node name="StatementBlock" type="MarginContainer" node_paths=PackedStringArray("bottom_snap", "template_editor")]
@@ -36,8 +36,9 @@ mouse_filter = 1
 script = ExtResource("2_lctqt")
 color = Color(1, 1, 1, 1)
 
-[node name="DragDropArea" parent="VBoxContainer/TopMarginContainer" instance=ExtResource("2_owgdx")]
+[node name="DragDropArea" parent="VBoxContainer/TopMarginContainer" instance=ExtResource("3_mbxhq")]
 layout_mode = 2
+mouse_default_cursor_shape = 2
 
 [node name="MarginContainer" type="MarginContainer" parent="VBoxContainer/TopMarginContainer"]
 layout_mode = 2
@@ -54,4 +55,4 @@ layout_mode = 2
 [node name="SnapPoint" parent="VBoxContainer" instance=ExtResource("3_5vaov")]
 layout_mode = 2
 
-[connection signal="mouse_down" from="VBoxContainer/TopMarginContainer/DragDropArea" to="." method="_on_drag_drop_area_mouse_down"]
+[connection signal="drag_started" from="VBoxContainer/TopMarginContainer/DragDropArea" to="." method="_on_drag_drop_area_drag_started"]

--- a/addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.gd
+++ b/addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.gd
@@ -1,16 +1,65 @@
 @tool
-extends MarginContainer
+## Drag drop area.
+##
+## A Control which watches for click and drag gestures beginning from itself.
+## It propagates events up to its parent, so it is possible to place this
+## control inside a control which processes input events such as [LineEdit].
+## If a drag occurs, it emits [signal drag_started].
+extends Control
 
-signal mouse_down
-signal mouse_up
+const Constants = preload("res://addons/block_code/ui/constants.gd")
+
+signal drag_started
+
+## True to require that the mouse move outside of the component before
+## [signal drag_started] is emitted.
+@export var drag_outside: bool = false
+
+var _drag_start_position: Vector2 = Vector2.INF
 
 
-func _on_gui_input(event):
-	if event is InputEventMouseButton and get_global_rect().has_point(event.global_position):
-		var mouse_event: InputEventMouseButton = event as InputEventMouseButton
-		if mouse_event.button_index == MOUSE_BUTTON_LEFT and mouse_event.pressed:
-			mouse_down.emit()
-			get_viewport().set_input_as_handled()
-		if mouse_event.button_index == MOUSE_BUTTON_LEFT and not mouse_event.pressed:
-			mouse_up.emit()
-			get_viewport().set_input_as_handled()
+func _gui_input(event: InputEvent) -> void:
+	# Watch for mouse clicks using _gui_input, so events are filtered based on
+	# rules of the GUI system.
+
+	if not event is InputEventMouseButton:
+		return
+
+	var button_event: InputEventMouseButton = event as InputEventMouseButton
+
+	if button_event.button_index != MOUSE_BUTTON_LEFT:
+		return
+
+	if button_event.double_click:
+		# Double click event (with the mouse released) has both pressed=true
+		# and double_click=true, so ignore it as a special case.
+		pass
+	elif button_event.pressed:
+		# Keep track of where the mouse click originated, but allow this
+		# event to propagate to other nodes.
+		_drag_start_position = event.global_position
+	else:
+		_drag_start_position = Vector2.INF
+
+
+func _input(event: InputEvent) -> void:
+	# Watch for mouse movements using _input. This way, we receive mouse
+	# movement events that occur outside of the component.
+
+	if not event is InputEventMouseMotion:
+		return
+
+	if _drag_start_position == Vector2.INF:
+		return
+
+	var motion_event: InputEventMouseMotion = event as InputEventMouseMotion
+
+	if drag_outside and get_global_rect().has_point(motion_event.global_position):
+		return
+
+	if _drag_start_position.distance_to(motion_event.global_position) < Constants.MINIMUM_DRAG_THRESHOLD:
+		return
+
+	get_viewport().set_input_as_handled()
+	drag_started.emit()
+	_drag_start_position = Vector2.INF

--- a/addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn
+++ b/addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn
@@ -2,13 +2,12 @@
 
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.gd" id="1_5vdxp"]
 
-[node name="DragDropArea" type="MarginContainer"]
+[node name="DragDropArea" type="Control"]
+layout_mode = 3
 anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
-mouse_default_cursor_shape = 2
+mouse_filter = 1
 script = ExtResource("1_5vdxp")
-
-[connection signal="gui_input" from="." to="." method="_on_gui_input"]

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
@@ -20,7 +20,6 @@ signal modified
 var default_value: Variant
 
 var _drag_start: Vector2 = Vector2.INF
-var _is_dragging: bool = false
 
 @onready var _panel := %Panel
 @onready var snap_point := %SnapPoint
@@ -156,6 +155,10 @@ func _ready():
 		set_raw_input(default_value)
 
 
+func _on_drag_drop_area_drag_started():
+	drag_started.emit()
+
+
 func get_snapped_block() -> Block:
 	return snap_point.get_snapped_block()
 
@@ -289,32 +292,3 @@ func _on_option_input_item_selected(index):
 
 func _on_snap_point_snapped_block_changed(block):
 	_update_visible_input()
-
-
-func _input(event: InputEvent) -> void:
-	if snap_point.has_snapped_block():
-		return
-
-	if event is InputEventMouseButton:
-		var button_event: InputEventMouseButton = event as InputEventMouseButton
-
-		if button_event.button_index != MOUSE_BUTTON_LEFT:
-			return
-
-		if button_event.double_click:
-			# Double click event (with the mouse released) has both pressed=true
-			# and double_click=true, so ignore it as a special case.
-			pass
-		elif button_event.pressed and get_global_rect().has_point(button_event.global_position):
-			# Keep track of where the mouse click originated, but allow this
-			# event to propagate to other nodes.
-			_drag_start = event.global_position
-		else:
-			_drag_start = Vector2.INF
-	elif _drag_start != Vector2.INF and event is InputEventMouseMotion:
-		var motion_event: InputEventMouseMotion = event as InputEventMouseMotion
-
-		if not get_global_rect().has_point(event.global_position) and _drag_start.distance_to(event.global_position) > Constants.MINIMUM_DRAG_THRESHOLD:
-			get_viewport().set_input_as_handled()
-			drag_started.emit()
-			_drag_start = Vector2.INF

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=10 format=3 uid="uid://cjvxs6euc6xbm"]
+[gd_scene load_steps=11 format=3 uid="uid://cjvxs6euc6xbm"]
 
 [ext_resource type="Script" path="res://addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd" id="1_rgmxn"]
+[ext_resource type="PackedScene" uid="uid://c7puyxpqcq6xo" path="res://addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.tscn" id="2_05gck"]
 [ext_resource type="PackedScene" uid="uid://b1oge52xhjqnu" path="res://addons/block_code/ui/blocks/utilities/snap_point/snap_point.tscn" id="2_6esp3"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_tn6h4"]
@@ -71,6 +72,10 @@ theme_override_styles/normal = SubResource("StyleBoxEmpty_6oowp")
 placeholder_text = "Parameter"
 expand_to_text_length = true
 
+[node name="DragDropArea" parent="InputSwitcher/TextInput/LineEdit" instance=ExtResource("2_05gck")]
+layout_mode = 1
+drag_outside = true
+
 [node name="ColorInput" type="ColorPickerButton" parent="InputSwitcher"]
 unique_name_in_owner = true
 visible = false
@@ -79,6 +84,10 @@ custom_minimum_size = Vector2(50, 0)
 layout_mode = 2
 mouse_default_cursor_shape = 2
 theme_override_styles/normal = SubResource("StyleBoxEmpty_5hq7f")
+
+[node name="DragDropArea" parent="InputSwitcher/ColorInput" instance=ExtResource("2_05gck")]
+layout_mode = 1
+drag_outside = true
 
 [node name="OptionInput" type="OptionButton" parent="InputSwitcher"]
 unique_name_in_owner = true
@@ -89,6 +98,10 @@ tooltip_text = "Parameter"
 theme_override_styles/normal = SubResource("StyleBoxEmpty_fjquj")
 action_mode = 1
 fit_to_longest_item = false
+
+[node name="DragDropArea" parent="InputSwitcher/OptionInput" instance=ExtResource("2_05gck")]
+layout_mode = 1
+drag_outside = true
 
 [node name="Vector2Input" type="MarginContainer" parent="InputSwitcher"]
 unique_name_in_owner = true
@@ -121,6 +134,10 @@ placeholder_text = "x"
 alignment = 1
 expand_to_text_length = true
 
+[node name="DragDropArea" parent="InputSwitcher/Vector2Input/HBoxContainer/XLineEdit" instance=ExtResource("2_05gck")]
+layout_mode = 1
+drag_outside = true
+
 [node name="Control3" type="Control" parent="InputSwitcher/Vector2Input/HBoxContainer"]
 layout_mode = 2
 size_flags_horizontal = 3
@@ -134,6 +151,10 @@ custom_minimum_size = Vector2(2, 0)
 layout_mode = 2
 size_flags_horizontal = 4
 color = Color(0.804743, 0.804743, 0.804743, 1)
+
+[node name="DragDropArea" parent="InputSwitcher/Vector2Input/HBoxContainer/CenterContainer/ColorRect" instance=ExtResource("2_05gck")]
+layout_mode = 1
+drag_outside = true
 
 [node name="Control4" type="Control" parent="InputSwitcher/Vector2Input/HBoxContainer"]
 layout_mode = 2
@@ -153,6 +174,10 @@ theme_override_styles/normal = SubResource("StyleBoxEmpty_6oowp")
 placeholder_text = "y"
 alignment = 1
 expand_to_text_length = true
+
+[node name="DragDropArea" parent="InputSwitcher/Vector2Input/HBoxContainer/YLineEdit" instance=ExtResource("2_05gck")]
+layout_mode = 1
+drag_outside = true
 
 [node name="Control2" type="Control" parent="InputSwitcher/Vector2Input/HBoxContainer"]
 layout_mode = 2
@@ -179,6 +204,10 @@ popup/item_0/text = "false"
 popup/item_1/text = "true"
 popup/item_1/id = 1
 
+[node name="DragDropArea" parent="InputSwitcher/BoolInput/BoolInputOption" instance=ExtResource("2_05gck")]
+layout_mode = 1
+drag_outside = true
+
 [node name="SnapPoint" parent="." instance=ExtResource("2_6esp3")]
 unique_name_in_owner = true
 layout_mode = 2
@@ -187,11 +216,18 @@ variant_type = 4
 
 [connection signal="focus_exited" from="InputSwitcher/TextInput/LineEdit" to="." method="_on_line_edit_focus_exited"]
 [connection signal="text_submitted" from="InputSwitcher/TextInput/LineEdit" to="." method="_on_line_edit_text_submitted"]
+[connection signal="drag_started" from="InputSwitcher/TextInput/LineEdit/DragDropArea" to="." method="_on_drag_drop_area_drag_started"]
 [connection signal="color_changed" from="InputSwitcher/ColorInput" to="." method="_on_color_input_color_changed"]
+[connection signal="drag_started" from="InputSwitcher/ColorInput/DragDropArea" to="." method="_on_drag_drop_area_drag_started"]
 [connection signal="item_selected" from="InputSwitcher/OptionInput" to="." method="_on_option_input_item_selected"]
+[connection signal="drag_started" from="InputSwitcher/OptionInput/DragDropArea" to="." method="_on_drag_drop_area_drag_started"]
 [connection signal="focus_exited" from="InputSwitcher/Vector2Input/HBoxContainer/XLineEdit" to="." method="_on_x_line_edit_focus_exited"]
 [connection signal="text_submitted" from="InputSwitcher/Vector2Input/HBoxContainer/XLineEdit" to="." method="_on_x_line_edit_text_submitted"]
+[connection signal="drag_started" from="InputSwitcher/Vector2Input/HBoxContainer/XLineEdit/DragDropArea" to="." method="_on_drag_drop_area_drag_started"]
+[connection signal="drag_started" from="InputSwitcher/Vector2Input/HBoxContainer/CenterContainer/ColorRect/DragDropArea" to="." method="_on_drag_drop_area_drag_started"]
 [connection signal="focus_exited" from="InputSwitcher/Vector2Input/HBoxContainer/YLineEdit" to="." method="_on_y_line_edit_focus_exited"]
 [connection signal="text_submitted" from="InputSwitcher/Vector2Input/HBoxContainer/YLineEdit" to="." method="_on_y_line_edit_text_submitted"]
+[connection signal="drag_started" from="InputSwitcher/Vector2Input/HBoxContainer/YLineEdit/DragDropArea" to="." method="_on_drag_drop_area_drag_started"]
 [connection signal="item_selected" from="InputSwitcher/BoolInput/BoolInputOption" to="." method="_on_option_input_item_selected"]
+[connection signal="drag_started" from="InputSwitcher/BoolInput/BoolInputOption/DragDropArea" to="." method="_on_drag_drop_area_drag_started"]
 [connection signal="snapped_block_changed" from="SnapPoint" to="." method="_on_snap_point_snapped_block_changed"]


### PR DESCRIPTION
Instead of using only _input to process events, use _gui_input to watch for mouse button events that are understood to be for an input control, but use _input to watch for mouse movement events which may occur outside of the control.

To work within the rules of Godot's GUI event system, we need to do this in a control which is a child of each input control. This is achieved using draggable_overlay.tscn.