### PR TITLE
DragDropArea: Add offset to drag_started signal

### DIFF
--- a/addons/block_code/drag_manager/drag_manager.gd
+++ b/addons/block_code/drag_manager/drag_manager.gd
@@ -33,15 +33,11 @@ func _process(_delta):
 		drag.update_drag_state()
 
 
-func drag_block(block: Block, copied_from: Block = null):
-	var offset: Vector2
-
+func drag_block(block: Block, copied_from: Block = null, offset: Vector2 = Vector2.ZERO):
 	if copied_from and copied_from.is_inside_tree():
-		offset = get_global_mouse_position() - copied_from.global_position
+		offset += get_global_mouse_position() - copied_from.global_position
 	elif block.is_inside_tree():
-		offset = get_global_mouse_position() - block.global_position
-	else:
-		offset = Vector2.ZERO
+		offset += get_global_mouse_position() - block.global_position
 
 	if _block_canvas.is_ancestor_of(block):
 		offset /= _block_canvas.zoom
@@ -71,9 +67,9 @@ func copy_block(block: Block) -> Block:
 	return _context.block_script.instantiate_block(block.definition)
 
 
-func copy_picked_block_and_drag(block: Block):
+func copy_picked_block_and_drag(block: Block, offset: Vector2):
 	var new_block: Block = copy_block(block)
-	drag_block(new_block, block)
+	drag_block(new_block, block, offset)
 
 
 func drag_ended():
@@ -99,6 +95,10 @@ func drag_ended():
 
 func connect_block_canvas_signals(block: Block):
 	if block.drag_started.get_connections().size() == 0:
-		block.drag_started.connect(drag_block)
+		block.drag_started.connect(_on_block_drag_started)
 	if block.modified.get_connections().size() == 0:
 		block.modified.connect(func(): block_modified.emit())
+
+
+func _on_block_drag_started(block: Block, offset: Vector2):
+	drag_block(block, null, offset)

--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -4,7 +4,7 @@ extends MarginContainer
 
 const BlockDefinition = preload("res://addons/block_code/code_generation/block_definition.gd")
 
-signal drag_started(block: Block)
+signal drag_started(block: Block, offset: Vector2)
 signal modified
 
 ## Color of block (optionally used to draw block color)
@@ -104,8 +104,8 @@ func _on_template_editor_modified():
 	modified.emit()
 
 
-func _on_template_editor_drag_started():
-	_drag_started()
+func _on_template_editor_drag_started(offset: Vector2):
+	_drag_started(offset)
 
 
 func _get_format_string() -> String:
@@ -193,8 +193,8 @@ static func get_scene_path():
 	push_error("Unimplemented.")
 
 
-func _drag_started():
-	drag_started.emit(self)
+func _drag_started(offset: Vector2 = Vector2.ZERO):
+	drag_started.emit(self, offset)
 
 
 func disconnect_signals():

--- a/addons/block_code/ui/blocks/control_block/control_block.gd
+++ b/addons/block_code/ui/blocks/control_block/control_block.gd
@@ -17,8 +17,8 @@ func _ready():
 	%SnapGutter.custom_minimum_size.x = Constants.CONTROL_MARGIN
 
 
-func _on_drag_drop_area_drag_started() -> void:
-	_drag_started()
+func _on_drag_drop_area_drag_started(offset: Vector2) -> void:
+	_drag_started(offset)
 
 
 static func get_block_class():

--- a/addons/block_code/ui/blocks/parameter_block/parameter_block.gd
+++ b/addons/block_code/ui/blocks/parameter_block/parameter_block.gd
@@ -30,8 +30,8 @@ func _ready():
 		_panel.add_theme_stylebox_override("panel", _panel_normal)
 
 
-func _on_drag_drop_area_drag_started() -> void:
-	_drag_started()
+func _on_drag_drop_area_drag_started(offset: Vector2) -> void:
+	_drag_started(offset)
 
 
 static func get_block_class():

--- a/addons/block_code/ui/blocks/statement_block/statement_block.gd
+++ b/addons/block_code/ui/blocks/statement_block/statement_block.gd
@@ -18,8 +18,8 @@ func _ready():
 	_background.color = color
 
 
-func _on_drag_drop_area_drag_started() -> void:
-	_drag_started()
+func _on_drag_drop_area_drag_started(offset: Vector2) -> void:
+	_drag_started(offset)
 
 
 static func get_block_class():

--- a/addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.gd
+++ b/addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.gd
@@ -9,7 +9,7 @@ extends Control
 
 const Constants = preload("res://addons/block_code/ui/constants.gd")
 
-signal drag_started
+signal drag_started(offset: Vector2)
 
 ## True to require that the mouse move outside of the component before
 ## [signal drag_started] is emitted.
@@ -61,5 +61,5 @@ func _input(event: InputEvent) -> void:
 		return
 
 	get_viewport().set_input_as_handled()
-	drag_started.emit()
+	drag_started.emit(_drag_start_position - motion_event.global_position)
 	_drag_start_position = Vector2.INF

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
@@ -1,7 +1,7 @@
 @tool
 extends MarginContainer
 
-signal drag_started
+signal drag_started(offset: Vector2)
 
 const Constants = preload("res://addons/block_code/ui/constants.gd")
 const OptionData = preload("res://addons/block_code/code_generation/option_data.gd")
@@ -155,8 +155,8 @@ func _ready():
 		set_raw_input(default_value)
 
 
-func _on_drag_drop_area_drag_started():
-	drag_started.emit()
+func _on_drag_drop_area_drag_started(offset: Vector2):
+	drag_started.emit(offset)
 
 
 func get_snapped_block() -> Block:

--- a/addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_output/parameter_output.gd
@@ -6,7 +6,6 @@ const ParameterBlock = preload("res://addons/block_code/ui/blocks/parameter_bloc
 
 var block: Block
 var parameter_name: String
-var output_block: Block
 var _block_name: String:
 	get:
 		return block.definition.name if block else ""
@@ -43,8 +42,8 @@ func _update_parameter_block():
 	_snap_point.add_child.call_deferred(parameter_block)
 
 
-func _on_parameter_block_drag_started(drag_block: Block):
-	block.drag_started.emit(drag_block)
+func _on_parameter_block_drag_started(drag_block: Block, offset: Vector2):
+	block.drag_started.emit(drag_block, offset)
 
 
 func _on_snap_point_snapped_block_changed(snap_block: Block):

--- a/addons/block_code/ui/blocks/utilities/template_editor/template_editor.gd
+++ b/addons/block_code/ui/blocks/utilities/template_editor/template_editor.gd
@@ -2,7 +2,7 @@
 class_name TemplateEditor
 extends Container
 
-signal drag_started
+signal drag_started(offset: Vector2)
 signal modified
 
 const BlockDefinition = preload("res://addons/block_code/code_generation/block_definition.gd")
@@ -140,5 +140,5 @@ func _append_output_parameter(parameter: Dictionary, id: int):
 	_container.add_child(parameter_output)
 
 
-func _on_parameter_input_drag_started():
-	drag_started.emit()
+func _on_parameter_input_drag_started(offset: Vector2):
+	drag_started.emit(offset)

--- a/addons/block_code/ui/picker/categories/block_category_display.gd
+++ b/addons/block_code/ui/picker/categories/block_category_display.gd
@@ -1,7 +1,7 @@
 @tool
 extends MarginContainer
 
-signal block_picked(block: Block)
+signal block_picked(block: Block, offset: Vector2)
 
 const BlockCategory = preload("res://addons/block_code/ui/picker/categories/block_category.gd")
 const BlockDefinition = preload("res://addons/block_code/code_generation/block_definition.gd")
@@ -67,7 +67,7 @@ func _get_or_create_block(block_definition: BlockDefinition) -> Block:
 	if block == null:
 		block = _context.block_script.instantiate_block(block_definition)
 		block.can_delete = false
-		block.drag_started.connect(func(block: Block): block_picked.emit(block))
+		block.drag_started.connect(func(block: Block, offset: Vector2): block_picked.emit(block, offset))
 		_blocks_container.add_child(block)
 		_blocks[block_definition.name] = block
 

--- a/addons/block_code/ui/picker/picker.gd
+++ b/addons/block_code/ui/picker/picker.gd
@@ -24,7 +24,7 @@ const CATEGORY_ORDER_OVERRIDE = {
 	"Graphics | Viewport": [&"viewport_width", &"viewport_height", &"viewport_center"],
 }
 
-signal block_picked(block: Block)
+signal block_picked(block: Block, offset: Vector2)
 signal variable_created(variable: VariableDefinition)
 
 @onready var _context := BlockEditorContext.get_default()
@@ -113,7 +113,7 @@ func _get_or_create_block_category_display(category: BlockCategory) -> BlockCate
 			block_category_display = VariableCategoryDisplayScene.instantiate()
 			block_category_display.variable_created.connect(func(variable): variable_created.emit(variable))
 		block_category_display.title = category.name if category else ""
-		block_category_display.block_picked.connect(func(block: Block): block_picked.emit(block))
+		block_category_display.block_picked.connect(func(block: Block, offset: Vector2): block_picked.emit(block, offset))
 
 		_block_list.add_child(block_category_display)
 		_category_displays[category.name] = block_category_display


### PR DESCRIPTION
In DragManager, use the offset to ensure the block being dragged is
positioned under the cursor based on where the user started dragging.

-----

Based on #236.