### PR TITLE
Pong: Use call method in node

### DIFF
--- a/addons/block_code/examples/pong_game/pong_game.tscn
+++ b/addons/block_code/examples/pong_game/pong_game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=81 format=3 uid="uid://tf7b8c64ecc0"]
+[gd_scene load_steps=82 format=3 uid="uid://tf7b8c64ecc0"]
 
 [ext_resource type="PackedScene" uid="uid://cg8ibi18um3vg" path="res://addons/block_code/examples/pong_game/space.tscn" id="1_y56ac"]
 [ext_resource type="Script" path="res://addons/block_code/block_code_node/block_code.gd" id="3_6jaq8"]
@@ -9,7 +9,7 @@
 [ext_resource type="Script" path="res://addons/block_code/code_generation/option_data.gd" id="7_3q6bj"]
 [ext_resource type="Script" path="res://addons/block_code/serialization/block_script_serialization.gd" id="7_uuuue"]
 [ext_resource type="Script" path="res://addons/block_code/code_generation/variable_definition.gd" id="9_lo3p1"]
-[ext_resource type="PackedScene" uid="uid://c7l70grmkauij" path="res://addons/block_code/examples/pong_game/ball.tscn" id="9_xrqll"]
+[ext_resource type="PackedScene" uid="uid://c7l70grmkauij" path="res://addons/block_code/examples/spawner/ball.tscn" id="9_xrqll"]
 [ext_resource type="Script" path="res://addons/block_code/serialization/value_block_serialization.gd" id="11_yafka"]
 [ext_resource type="PackedScene" uid="uid://fhoapg3anjsu" path="res://addons/block_code/examples/pong_game/goal_area.tscn" id="12_nqmxu"]
 [ext_resource type="Script" path="res://addons/block_code/simple_nodes/simple_scoring/simple_scoring.gd" id="13_tg3yk"]
@@ -352,29 +352,36 @@ func _on_body_entered(something: Node2D):
 "
 version = 0
 
-[sub_resource type="Resource" id="Resource_c2lvs"]
+[sub_resource type="Resource" id="Resource_2j063"]
 script = ExtResource("11_yafka")
 name = &"area2d_on_entered:something"
 arguments = {}
 
-[sub_resource type="Resource" id="Resource_oejwf"]
+[sub_resource type="Resource" id="Resource_ar2nl"]
 script = ExtResource("11_yafka")
 name = &"is_node_in_group"
 arguments = {
 "group": "balls",
-"node": SubResource("Resource_c2lvs")
+"node": SubResource("Resource_2j063")
 }
 
-[sub_resource type="Resource" id="Resource_yrdnq"]
+[sub_resource type="Resource" id="Resource_53g7x"]
+script = ExtResource("11_yafka")
+name = &"get_node"
+arguments = {
+"path": NodePath("../SimpleScoring")
+}
+
+[sub_resource type="Resource" id="Resource_stgye"]
 script = ExtResource("4_qtggh")
-name = &"call_method_group"
+name = &"call_method_node"
 children = Array[ExtResource("4_qtggh")]([])
 arguments = {
-"group": "scoring",
-"method_name": "goal_left"
+"method_name": "goal_left",
+"node": SubResource("Resource_53g7x")
 }
 
-[sub_resource type="Resource" id="Resource_tfvi8"]
+[sub_resource type="Resource" id="Resource_p10a0"]
 script = ExtResource("4_qtggh")
 name = &"call_method_group"
 children = Array[ExtResource("4_qtggh")]([])
@@ -383,29 +390,29 @@ arguments = {
 "method_name": "reset"
 }
 
-[sub_resource type="Resource" id="Resource_ofslp"]
+[sub_resource type="Resource" id="Resource_3wwda"]
 script = ExtResource("4_qtggh")
 name = &"if"
-children = Array[ExtResource("4_qtggh")]([SubResource("Resource_yrdnq"), SubResource("Resource_tfvi8")])
+children = Array[ExtResource("4_qtggh")]([SubResource("Resource_stgye"), SubResource("Resource_p10a0")])
 arguments = {
-"condition": SubResource("Resource_oejwf")
+"condition": SubResource("Resource_ar2nl")
 }
 
-[sub_resource type="Resource" id="Resource_igjon"]
+[sub_resource type="Resource" id="Resource_w0w2g"]
 script = ExtResource("4_qtggh")
 name = &"area2d_on_entered"
-children = Array[ExtResource("4_qtggh")]([SubResource("Resource_ofslp")])
+children = Array[ExtResource("4_qtggh")]([SubResource("Resource_3wwda")])
 arguments = {}
 
-[sub_resource type="Resource" id="Resource_jef50"]
+[sub_resource type="Resource" id="Resource_xwspv"]
 script = ExtResource("5_omlge")
-root = SubResource("Resource_igjon")
+root = SubResource("Resource_w0w2g")
 canvas_position = Vector2(0, 25)
 
 [sub_resource type="Resource" id="Resource_4xylj"]
 script = ExtResource("7_uuuue")
 script_inherits = "Area2D"
-block_serialization_trees = Array[ExtResource("5_omlge")]([SubResource("Resource_jef50")])
+block_serialization_trees = Array[ExtResource("5_omlge")]([SubResource("Resource_xwspv")])
 variables = Array[ExtResource("9_lo3p1")]([])
 generated_script = "extends Area2D
 
@@ -416,35 +423,42 @@ func _init():
 func _on_body_entered(something: Node2D):
 
 	if ((something).is_in_group('balls')):
-		get_tree().call_group('scoring', 'goal_left')
+		(get_node(\"../SimpleScoring\")).call('goal_left')
 		get_tree().call_group('balls', 'reset')
 
 "
 version = 0
 
-[sub_resource type="Resource" id="Resource_hwdk4"]
+[sub_resource type="Resource" id="Resource_turid"]
 script = ExtResource("11_yafka")
 name = &"area2d_on_entered:something"
 arguments = {}
 
-[sub_resource type="Resource" id="Resource_2lbji"]
+[sub_resource type="Resource" id="Resource_d1w0q"]
 script = ExtResource("11_yafka")
 name = &"is_node_in_group"
 arguments = {
 "group": "balls",
-"node": SubResource("Resource_hwdk4")
+"node": SubResource("Resource_turid")
 }
 
-[sub_resource type="Resource" id="Resource_7xiwx"]
+[sub_resource type="Resource" id="Resource_0c6ok"]
+script = ExtResource("11_yafka")
+name = &"get_node"
+arguments = {
+"path": NodePath("../SimpleScoring")
+}
+
+[sub_resource type="Resource" id="Resource_wwo85"]
 script = ExtResource("4_qtggh")
-name = &"call_method_group"
+name = &"call_method_node"
 children = Array[ExtResource("4_qtggh")]([])
 arguments = {
-"group": "scoring",
-"method_name": "goal_right"
+"method_name": "goal_right",
+"node": SubResource("Resource_0c6ok")
 }
 
-[sub_resource type="Resource" id="Resource_2a1no"]
+[sub_resource type="Resource" id="Resource_tb1lq"]
 script = ExtResource("4_qtggh")
 name = &"call_method_group"
 children = Array[ExtResource("4_qtggh")]([])
@@ -453,29 +467,29 @@ arguments = {
 "method_name": "reset"
 }
 
-[sub_resource type="Resource" id="Resource_6861n"]
+[sub_resource type="Resource" id="Resource_u8yle"]
 script = ExtResource("4_qtggh")
 name = &"if"
-children = Array[ExtResource("4_qtggh")]([SubResource("Resource_7xiwx"), SubResource("Resource_2a1no")])
+children = Array[ExtResource("4_qtggh")]([SubResource("Resource_wwo85"), SubResource("Resource_tb1lq")])
 arguments = {
-"condition": SubResource("Resource_2lbji")
+"condition": SubResource("Resource_d1w0q")
 }
 
-[sub_resource type="Resource" id="Resource_dugxd"]
+[sub_resource type="Resource" id="Resource_37m3y"]
 script = ExtResource("4_qtggh")
 name = &"area2d_on_entered"
-children = Array[ExtResource("4_qtggh")]([SubResource("Resource_6861n")])
+children = Array[ExtResource("4_qtggh")]([SubResource("Resource_u8yle")])
 arguments = {}
 
-[sub_resource type="Resource" id="Resource_icwio"]
+[sub_resource type="Resource" id="Resource_xxs51"]
 script = ExtResource("5_omlge")
-root = SubResource("Resource_dugxd")
+root = SubResource("Resource_37m3y")
 canvas_position = Vector2(50, 25)
 
 [sub_resource type="Resource" id="Resource_xoc8a"]
 script = ExtResource("7_uuuue")
 script_inherits = "Area2D"
-block_serialization_trees = Array[ExtResource("5_omlge")]([SubResource("Resource_icwio")])
+block_serialization_trees = Array[ExtResource("5_omlge")]([SubResource("Resource_xxs51")])
 variables = Array[ExtResource("9_lo3p1")]([])
 generated_script = "extends Area2D
 
@@ -486,13 +500,13 @@ func _init():
 func _on_body_entered(something: Node2D):
 
 	if ((something).is_in_group('balls')):
-		get_tree().call_group('scoring', 'goal_right')
+		(get_node(\"../SimpleScoring\")).call('goal_right')
 		get_tree().call_group('balls', 'reset')
 
 "
 version = 0
 
-[sub_resource type="Resource" id="Resource_o7ugj"]
+[sub_resource type="Resource" id="Resource_stylb"]
 script = ExtResource("4_qtggh")
 name = &"simplescoring_set_score_player_1"
 children = Array[ExtResource("4_qtggh")]([])
@@ -500,7 +514,7 @@ arguments = {
 "score": 0
 }
 
-[sub_resource type="Resource" id="Resource_spykn"]
+[sub_resource type="Resource" id="Resource_eigru"]
 script = ExtResource("4_qtggh")
 name = &"simplescoring_set_score_player_2"
 children = Array[ExtResource("4_qtggh")]([])
@@ -508,26 +522,18 @@ arguments = {
 "score": 0
 }
 
-[sub_resource type="Resource" id="Resource_nucg0"]
-script = ExtResource("4_qtggh")
-name = &"add_to_group"
-children = Array[ExtResource("4_qtggh")]([])
-arguments = {
-"group": "scoring"
-}
-
-[sub_resource type="Resource" id="Resource_6brri"]
+[sub_resource type="Resource" id="Resource_n3u3y"]
 script = ExtResource("4_qtggh")
 name = &"ready"
-children = Array[ExtResource("4_qtggh")]([SubResource("Resource_o7ugj"), SubResource("Resource_spykn"), SubResource("Resource_nucg0")])
+children = Array[ExtResource("4_qtggh")]([SubResource("Resource_stylb"), SubResource("Resource_eigru")])
 arguments = {}
 
-[sub_resource type="Resource" id="Resource_v71gd"]
+[sub_resource type="Resource" id="Resource_wbpd3"]
 script = ExtResource("5_omlge")
-root = SubResource("Resource_6brri")
+root = SubResource("Resource_n3u3y")
 canvas_position = Vector2(25, 0)
 
-[sub_resource type="Resource" id="Resource_4y2px"]
+[sub_resource type="Resource" id="Resource_jn5i5"]
 script = ExtResource("4_qtggh")
 name = &"simplescoring_change_score_player_1"
 children = Array[ExtResource("4_qtggh")]([])
@@ -535,20 +541,20 @@ arguments = {
 "score": 1
 }
 
-[sub_resource type="Resource" id="Resource_ilawr"]
+[sub_resource type="Resource" id="Resource_mg3qf"]
 script = ExtResource("4_qtggh")
 name = &"define_method"
-children = Array[ExtResource("4_qtggh")]([SubResource("Resource_4y2px")])
+children = Array[ExtResource("4_qtggh")]([SubResource("Resource_jn5i5")])
 arguments = {
 "method_name": &"goal_right"
 }
 
-[sub_resource type="Resource" id="Resource_8e220"]
+[sub_resource type="Resource" id="Resource_vmh6a"]
 script = ExtResource("5_omlge")
-root = SubResource("Resource_ilawr")
+root = SubResource("Resource_mg3qf")
 canvas_position = Vector2(25, 250)
 
-[sub_resource type="Resource" id="Resource_1fx1n"]
+[sub_resource type="Resource" id="Resource_ja52s"]
 script = ExtResource("4_qtggh")
 name = &"simplescoring_change_score_player_2"
 children = Array[ExtResource("4_qtggh")]([])
@@ -556,23 +562,23 @@ arguments = {
 "score": 1
 }
 
-[sub_resource type="Resource" id="Resource_mef5h"]
+[sub_resource type="Resource" id="Resource_w80fi"]
 script = ExtResource("4_qtggh")
 name = &"define_method"
-children = Array[ExtResource("4_qtggh")]([SubResource("Resource_1fx1n")])
+children = Array[ExtResource("4_qtggh")]([SubResource("Resource_ja52s")])
 arguments = {
 "method_name": &"goal_left"
 }
 
-[sub_resource type="Resource" id="Resource_uty0f"]
+[sub_resource type="Resource" id="Resource_npfqa"]
 script = ExtResource("5_omlge")
-root = SubResource("Resource_mef5h")
+root = SubResource("Resource_w80fi")
 canvas_position = Vector2(25, 400)
 
 [sub_resource type="Resource" id="Resource_q418f"]
 script = ExtResource("7_uuuue")
 script_inherits = "SimpleScoring"
-block_serialization_trees = Array[ExtResource("5_omlge")]([SubResource("Resource_v71gd"), SubResource("Resource_8e220"), SubResource("Resource_uty0f")])
+block_serialization_trees = Array[ExtResource("5_omlge")]([SubResource("Resource_wbpd3"), SubResource("Resource_vmh6a"), SubResource("Resource_npfqa")])
 variables = Array[ExtResource("9_lo3p1")]([])
 generated_script = "extends SimpleScoring
 
@@ -580,7 +586,6 @@ generated_script = "extends SimpleScoring
 func _ready():
 	score_left = 0
 	score_right = 0
-	add_to_group('scoring')
 
 func goal_right():
 	score_left += 1


### PR DESCRIPTION
Instead of setting a group for the "SimpleScoring" node, use the new call_method_node block.