### PR TITLE
blocks: Add groups option block extension

### DIFF
--- a/addons/block_code/blocks/communication/add_node_to_group.tres
+++ b/addons/block_code/blocks/communication/add_node_to_group.tres
@@ -1,6 +1,13 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://bpvefei72nh3a"]
+[gd_resource type="Resource" load_steps=5 format=3 uid="uid://bpvefei72nh3a"]
 
 [ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_5qal7"]
+[ext_resource type="Script" path="res://addons/block_code/code_generation/option_data.gd" id="1_auf06"]
+[ext_resource type="Script" path="res://addons/block_code/blocks/communication/groups.gd" id="1_p83c7"]
+
+[sub_resource type="Resource" id="Resource_sus0f"]
+script = ExtResource("1_auf06")
+selected = 0
+items = []
 
 [resource]
 script = ExtResource("1_5qal7")
@@ -10,8 +17,11 @@ description = "Add the node into the group"
 category = "Communication | Groups"
 type = 2
 variant_type = 0
-display_template = "add {node: OBJECT} to group {group: STRING}"
-code_template = "{node}.add_to_group({group})"
-defaults = {}
+display_template = "add {node: OBJECT} to group {group: NIL}"
+code_template = "{node}.add_to_group(\\\"{group}\\\")"
+defaults = {
+"group": SubResource("Resource_sus0f")
+}
 signal_name = ""
 scope = ""
+extension_script = ExtResource("1_p83c7")

--- a/addons/block_code/blocks/communication/add_to_group.tres
+++ b/addons/block_code/blocks/communication/add_to_group.tres
@@ -1,6 +1,13 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://bvrmau8atjx1x"]
+[gd_resource type="Resource" load_steps=5 format=3 uid="uid://bvrmau8atjx1x"]
 
+[ext_resource type="Script" path="res://addons/block_code/code_generation/option_data.gd" id="1_aom4j"]
 [ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_bcm71"]
+[ext_resource type="Script" path="res://addons/block_code/blocks/communication/groups.gd" id="2_42ixf"]
+
+[sub_resource type="Resource" id="Resource_fk0wa"]
+script = ExtResource("1_aom4j")
+selected = 0
+items = []
 
 [resource]
 script = ExtResource("1_bcm71")
@@ -10,8 +17,11 @@ description = "Add this node into the group"
 category = "Communication | Groups"
 type = 2
 variant_type = 0
-display_template = "add to group {group: STRING}"
-code_template = "add_to_group({group})"
-defaults = {}
+display_template = "add to group {group: NIL}"
+code_template = "add_to_group(\\\"{group}\\\")"
+defaults = {
+"group": SubResource("Resource_fk0wa")
+}
 signal_name = ""
 scope = ""
+extension_script = ExtResource("2_42ixf")

--- a/addons/block_code/blocks/communication/call_method_group.tres
+++ b/addons/block_code/blocks/communication/call_method_group.tres
@@ -1,6 +1,13 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://c15vtdfihdxb8"]
+[gd_resource type="Resource" load_steps=5 format=3 uid="uid://c15vtdfihdxb8"]
 
+[ext_resource type="Script" path="res://addons/block_code/code_generation/option_data.gd" id="1_3nuts"]
 [ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_mlm68"]
+[ext_resource type="Script" path="res://addons/block_code/blocks/communication/groups.gd" id="1_of577"]
+
+[sub_resource type="Resource" id="Resource_f4ctg"]
+script = ExtResource("1_3nuts")
+selected = 0
+items = []
 
 [resource]
 script = ExtResource("1_mlm68")
@@ -10,8 +17,11 @@ description = "Calls the method/function on each member of the given group"
 category = "Communication | Methods"
 type = 2
 variant_type = 0
-display_template = "call method {method_name: STRING} in group {group: STRING}"
-code_template = "get_tree().call_group({group}, {method_name})"
-defaults = {}
+display_template = "call method {method_name: STRING} in group {group: NIL}"
+code_template = "get_tree().call_group(\\\"{group\\\"}, {method_name})"
+defaults = {
+"group": SubResource("Resource_f4ctg")
+}
 signal_name = ""
 scope = ""
+extension_script = ExtResource("1_of577")

--- a/addons/block_code/blocks/communication/groups.gd
+++ b/addons/block_code/blocks/communication/groups.gd
@@ -1,0 +1,71 @@
+@tool
+## Common BlockExtension for scene group options.
+extends BlockExtension
+
+const OptionData = preload("res://addons/block_code/code_generation/option_data.gd")
+const Util = preload("res://addons/block_code/ui/util.gd")
+
+
+# Global groups are just project settings in the global_group group.
+# ProjectSettings doesn't offer an API to get the project groups or to get all
+# settings. Fortunately, settings are simply implemented as properties on the
+# ProjectSettings object.
+static func _add_global_groups(groups: Dictionary):
+	for prop in ProjectSettings.get_property_list():
+		var name: String = prop["name"]
+		var parts := name.split("/", false, 1)
+		if parts[0] == "global_group":
+			groups[parts[1]] = null
+
+
+# Add all the groups in a node and its children, ignoring internal _ prefixed
+# groups.
+static func _add_node_groups(groups: Dictionary, node: Node):
+	for group in node.get_groups():
+		if not group.begins_with("_"):
+			groups[String(group)] = null
+
+	for child in node.get_children():
+		_add_node_groups(groups, child)
+
+
+func _get_edited_scene_groups() -> Array[String]:
+	var groups: Dictionary
+	_add_global_groups(groups)
+
+	var root := context_node.get_tree().edited_scene_root
+	_add_node_groups(groups, root)
+
+	var sorted_groups: Array[String]
+	sorted_groups.assign(groups.keys())
+	sorted_groups.sort()
+	return sorted_groups
+
+
+func _init():
+	# FIXME: Only global group changes are monitored. Scene local groups should
+	# also be monitored, but godot does not have any reasonable API to do that.
+	ProjectSettings.settings_changed.connect(_on_project_settings_changed)
+
+
+func _context_node_changed():
+	# If the context node changed, the scene local groups need to be updated.
+	changed.emit()
+
+
+func get_defaults() -> Dictionary:
+	if not context_node:
+		return {}
+
+	# The default groups are only needed in the editor.
+	if not Util.node_is_part_of_edited_scene(context_node):
+		return {}
+
+	var groups: Array[String] = _get_edited_scene_groups()
+	return {"group": OptionData.new(groups)}
+
+
+func _on_project_settings_changed():
+	# FIXME: The global groups should be cached and compared so that the
+	# defaults are only changed when the global groups actually change.
+	changed.emit()

--- a/addons/block_code/blocks/communication/is_in_group.tres
+++ b/addons/block_code/blocks/communication/is_in_group.tres
@@ -1,6 +1,13 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://q4cnstftvsiu"]
+[gd_resource type="Resource" load_steps=5 format=3 uid="uid://q4cnstftvsiu"]
 
+[ext_resource type="Script" path="res://addons/block_code/code_generation/option_data.gd" id="1_cla3i"]
 [ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_tjyq5"]
+[ext_resource type="Script" path="res://addons/block_code/blocks/communication/groups.gd" id="2_o165d"]
+
+[sub_resource type="Resource" id="Resource_d0v0d"]
+script = ExtResource("1_cla3i")
+selected = 0
+items = []
 
 [resource]
 script = ExtResource("1_tjyq5")
@@ -10,8 +17,11 @@ description = "Is this node in the group"
 category = "Communication | Groups"
 type = 3
 variant_type = 1
-display_template = "is in group {group: STRING}"
-code_template = "is_in_group({group})"
-defaults = {}
+display_template = "is in group {group: NIL}"
+code_template = "is_in_group(\\\"{group}\\\")"
+defaults = {
+"group": SubResource("Resource_d0v0d")
+}
 signal_name = ""
 scope = ""
+extension_script = ExtResource("2_o165d")

--- a/addons/block_code/blocks/communication/is_node_in_group.tres
+++ b/addons/block_code/blocks/communication/is_node_in_group.tres
@@ -1,6 +1,13 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://bbtdxeey74x67"]
+[gd_resource type="Resource" load_steps=5 format=3 uid="uid://bbtdxeey74x67"]
 
 [ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_5krrs"]
+[ext_resource type="Script" path="res://addons/block_code/blocks/communication/groups.gd" id="1_r4prw"]
+[ext_resource type="Script" path="res://addons/block_code/code_generation/option_data.gd" id="1_y4j0k"]
+
+[sub_resource type="Resource" id="Resource_o38ym"]
+script = ExtResource("1_y4j0k")
+selected = 0
+items = []
 
 [resource]
 script = ExtResource("1_5krrs")
@@ -10,8 +17,11 @@ description = "Is the node in the group"
 category = "Communication | Groups"
 type = 3
 variant_type = 1
-display_template = "{node: OBJECT} is in group {group: STRING}"
-code_template = "{node}.is_in_group({group})"
-defaults = {}
+display_template = "{node: OBJECT} is in group {group: NIL}"
+code_template = "{node}.is_in_group(\\\"{group}\\\")"
+defaults = {
+"group": SubResource("Resource_o38ym")
+}
 signal_name = ""
 scope = ""
+extension_script = ExtResource("1_r4prw")

--- a/addons/block_code/blocks/communication/remove_from_group.tres
+++ b/addons/block_code/blocks/communication/remove_from_group.tres
@@ -1,6 +1,13 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://dgenw5wyqorvq"]
+[gd_resource type="Resource" load_steps=5 format=3 uid="uid://dgenw5wyqorvq"]
 
 [ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_cdwef"]
+[ext_resource type="Script" path="res://addons/block_code/blocks/communication/groups.gd" id="1_i50fw"]
+[ext_resource type="Script" path="res://addons/block_code/code_generation/option_data.gd" id="1_mnxp7"]
+
+[sub_resource type="Resource" id="Resource_45b71"]
+script = ExtResource("1_mnxp7")
+selected = 0
+items = []
 
 [resource]
 script = ExtResource("1_cdwef")
@@ -10,8 +17,11 @@ description = "Remove this node from the group"
 category = "Communication | Groups"
 type = 2
 variant_type = 0
-display_template = "remove from group {group: STRING}"
-code_template = "remove_from_group({group})"
-defaults = {}
+display_template = "remove from group {group: NIL}"
+code_template = "remove_from_group(\\\"{group}\\\")"
+defaults = {
+"group": SubResource("Resource_45b71")
+}
 signal_name = ""
 scope = ""
+extension_script = ExtResource("1_i50fw")

--- a/addons/block_code/blocks/communication/remove_node_from_group.tres
+++ b/addons/block_code/blocks/communication/remove_node_from_group.tres
@@ -1,6 +1,13 @@
-[gd_resource type="Resource" load_steps=2 format=3 uid="uid://b2dwk77hnri8y"]
+[gd_resource type="Resource" load_steps=5 format=3 uid="uid://b2dwk77hnri8y"]
 
+[ext_resource type="Script" path="res://addons/block_code/code_generation/option_data.gd" id="1_clwhe"]
+[ext_resource type="Script" path="res://addons/block_code/blocks/communication/groups.gd" id="1_h3lhb"]
 [ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_pec24"]
+
+[sub_resource type="Resource" id="Resource_03rge"]
+script = ExtResource("1_clwhe")
+selected = 0
+items = []
 
 [resource]
 script = ExtResource("1_pec24")
@@ -10,8 +17,11 @@ description = "Remove the node from the group"
 category = "Communication | Groups"
 type = 2
 variant_type = 0
-display_template = "remove {node: OBJECT} from group {group: STRING}"
-code_template = "{node}.remove_from_group({group})"
-defaults = {}
+display_template = "remove {node: OBJECT} from group {group: NIL}"
+code_template = "{node}.remove_from_group(\\\"{group}\\\")"
+defaults = {
+"group": SubResource("Resource_03rge")
+}
 signal_name = ""
 scope = ""
+extension_script = ExtResource("1_h3lhb")

--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -88,6 +88,12 @@ func get_parameter_values() -> Dictionary:
 	return template_editor.get_parameter_values()
 
 
+## Use the current BlockEditorContext components
+func refresh_context():
+	if _context and _block_extension:
+		_block_extension.context_node = _context.parent_node
+
+
 func _update_template_editor():
 	if template_editor == null:
 		return

--- a/addons/block_code/ui/picker/categories/block_category_display.gd
+++ b/addons/block_code/ui/picker/categories/block_category_display.gd
@@ -70,5 +70,9 @@ func _get_or_create_block(block_definition: BlockDefinition) -> Block:
 		block.drag_started.connect(func(block: Block): block_picked.emit(block))
 		_blocks_container.add_child(block)
 		_blocks[block_definition.name] = block
+	else:
+		# If the block is being reused, make sure the context corresponds to
+		# the current BlockCode node.
+		block.refresh_context()
 
 	return block


### PR DESCRIPTION
Several blocks work with node groups. Rather than having the user enter the group, offer the current groups as options. This is trickier than expected since Godot offers no API to get the current groups. Finding them involves 2 parts:

* Get scene local groups by calling get_groups() on each node in the scene.

* Get project global groups (starting in 4.3) by getting the `global_group` values in the project settings.

Monitoring for changes to the global groups is possible by listening for project settings changes. Monitoring for local group changes is not possible since the only events that occur are internal to Godot and not available in GDScript.

https://phabricator.endlessm.com/T35647

This is a naive implementation. The groups are specific to the scene and project. Rather than have each `Block` maintain its own list, it should be gathered in the `BlockCode` node or even the `BlockCodePlugin`. I spent far too long trying to make that work well, but I decided to just put up this simple implementation now.

As noted above, the biggest problem is that the scene local groups are not monitored. So, if you add a node to a group, the Blocks won't be updated with the new group. Also, since the `add_to_group` blocks only offer existing groups, it takes away the means of creating scene local groups dynamically. That may not be that bad, though, since that would only happen at runtime and you wouldn't be able to query for the presence of the group.