### PR TITLE
BlockCanvas: Use _gui_input instead of _input

### DIFF
--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -364,7 +364,7 @@ func _on_replace_block_code_button_pressed():
 	replace_block_code.emit()
 
 
-func _input(event):
+func _gui_input(event):
 	if event is InputEventKey:
 		if event.keycode == KEY_SHIFT:
 			set_mouse_override(event.pressed)

--- a/addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.gd
+++ b/addons/block_code/ui/blocks/utilities/drag_drop_area/drag_drop_area.gd
@@ -44,7 +44,8 @@ func _gui_input(event: InputEvent) -> void:
 
 func _input(event: InputEvent) -> void:
 	# Watch for mouse movements using _input. This way, we receive mouse
-	# movement events that occur outside of the component.
+	# motion events that occur outside of the component before the GUI system
+	# does.
 
 	if not event is InputEventMouseMotion:
 		return


### PR DESCRIPTION
Use the _gui_input virtual function to pan and zoom the block canvas, instead of _input. This way, events are filtered according to the block canvas's visibility. As a side-effect, the block canvas processes input events after any containing widgets. For example, middle clicking inside a parameter input component will no longer begin panning. However, this is a better situation than the block canvas handling input events regardless of its visibility.

Closes: https://github.com/endlessm/godot-block-coding/issues/184