### PR TITLE
Fix error in simple_spawner.gd with Godot 4.2.2

### DIFF
--- a/addons/block_code/simple_spawner/simple_spawner.gd
+++ b/addons/block_code/simple_spawner/simple_spawner.gd
@@ -79,7 +79,7 @@ func spawn_once():
 	if scenes.size() == 0:
 		return
 
-	_spawned_scenes = _spawned_scenes.filter(is_instance_valid)
+	_spawned_scenes = _spawned_scenes.filter(func(instance): return is_instance_valid(instance))
 
 	if spawn_limit != 0 and _spawned_scenes.size() >= spawn_limit:
 		if limit_behavior == LimitBehavior.NO_SPAWN:


### PR DESCRIPTION
With Godot 4.3, it is possible to use is_instance_valid as a Callable. To support Godot 4.2.2, we must use an anonymous function instead.