### PR TITLE
blocks: Use string type for group names

### DIFF
--- a/addons/block_code/blocks/communication/add_node_to_group.tres
+++ b/addons/block_code/blocks/communication/add_node_to_group.tres
@@ -17,8 +17,8 @@ description = "Add the node into the group"
 category = "Communication | Groups"
 type = 2
 variant_type = 0
-display_template = "add {node: OBJECT} to group {group: NIL}"
-code_template = "{node}.add_to_group(\\\"{group}\\\")"
+display_template = "add {node: OBJECT} to group {group: STRING}"
+code_template = "{node}.add_to_group({group})"
 defaults = {
 "group": SubResource("Resource_sus0f")
 }

--- a/addons/block_code/blocks/communication/add_to_group.tres
+++ b/addons/block_code/blocks/communication/add_to_group.tres
@@ -17,8 +17,8 @@ description = "Add this node into the group"
 category = "Communication | Groups"
 type = 2
 variant_type = 0
-display_template = "add to group {group: NIL}"
-code_template = "add_to_group(\\\"{group}\\\")"
+display_template = "add to group {group: STRING}"
+code_template = "add_to_group({group})"
 defaults = {
 "group": SubResource("Resource_fk0wa")
 }

--- a/addons/block_code/blocks/communication/call_method_group.tres
+++ b/addons/block_code/blocks/communication/call_method_group.tres
@@ -17,8 +17,8 @@ description = "Calls the method/function on each member of the given group"
 category = "Communication | Methods"
 type = 2
 variant_type = 0
-display_template = "call method {method_name: STRING} in group {group: NIL}"
-code_template = "get_tree().call_group(\\\"{group\\\"}, {method_name})"
+display_template = "call method {method_name: STRING} in group {group: STRING}"
+code_template = "get_tree().call_group({group}, {method_name})"
 defaults = {
 "group": SubResource("Resource_f4ctg")
 }

--- a/addons/block_code/blocks/communication/is_in_group.tres
+++ b/addons/block_code/blocks/communication/is_in_group.tres
@@ -17,8 +17,8 @@ description = "Is this node in the group"
 category = "Communication | Groups"
 type = 3
 variant_type = 1
-display_template = "is in group {group: NIL}"
-code_template = "is_in_group(\\\"{group}\\\")"
+display_template = "is in group {group: STRING}"
+code_template = "is_in_group({group})"
 defaults = {
 "group": SubResource("Resource_d0v0d")
 }

--- a/addons/block_code/blocks/communication/is_node_in_group.tres
+++ b/addons/block_code/blocks/communication/is_node_in_group.tres
@@ -17,8 +17,8 @@ description = "Is the node in the group"
 category = "Communication | Groups"
 type = 3
 variant_type = 1
-display_template = "{node: OBJECT} is in group {group: NIL}"
-code_template = "{node}.is_in_group(\\\"{group}\\\")"
+display_template = "{node: OBJECT} is in group {group: STRING}"
+code_template = "{node}.is_in_group({group})"
 defaults = {
 "group": SubResource("Resource_o38ym")
 }

--- a/addons/block_code/blocks/communication/remove_from_group.tres
+++ b/addons/block_code/blocks/communication/remove_from_group.tres
@@ -17,8 +17,8 @@ description = "Remove this node from the group"
 category = "Communication | Groups"
 type = 2
 variant_type = 0
-display_template = "remove from group {group: NIL}"
-code_template = "remove_from_group(\\\"{group}\\\")"
+display_template = "remove from group {group: STRING}"
+code_template = "remove_from_group({group})"
 defaults = {
 "group": SubResource("Resource_45b71")
 }


### PR DESCRIPTION
This spares us some grief in the code templates for different group-related blocks.

https://phabricator.endlessm.com/T35647