### PR TITLE
Vector2 x and y blocks

### DIFF
--- a/addons/block_code/blocks/math/vector2_x.tres
+++ b/addons/block_code/blocks/math/vector2_x.tres
@@ -11,7 +11,7 @@ category = "Math"
 type = 3
 variant_type = 3
 display_template = "x of {vector2: VECTOR2}"
-code_template = "({vector2}).x"
+code_template = "{vector2}.x"
 defaults = {
 "vector2": Vector2(0, 0)
 }

--- a/addons/block_code/blocks/math/vector2_x.tres
+++ b/addons/block_code/blocks/math/vector2_x.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" load_steps=2 format=3 uid="uid://btsfimn63xhi2"]
+
+[ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_dvsrc"]
+
+[resource]
+script = ExtResource("1_dvsrc")
+name = &"vector2_x"
+target_node_class = ""
+description = "Gives the x of a [i]Vector2[/i]"
+category = "Math"
+type = 3
+variant_type = 3
+display_template = "x of {vector2: VECTOR2}"
+code_template = "({vector2}).x"
+defaults = {
+"vector2": Vector2(0, 0)
+}
+signal_name = ""
+scope = ""

--- a/addons/block_code/blocks/math/vector2_y.tres
+++ b/addons/block_code/blocks/math/vector2_y.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" load_steps=2 format=3 uid="uid://ccbrbp4lee3wt"]
+
+[ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_wuold"]
+
+[resource]
+script = ExtResource("1_wuold")
+name = &"vector2_y"
+target_node_class = ""
+description = "Gives the y of a [i]Vector2[/i]"
+category = "Math"
+type = 3
+variant_type = 3
+display_template = "y of {vector2: VECTOR2}"
+code_template = "({vector2}).y"
+defaults = {
+"vector2": Vector2(0, 0)
+}
+signal_name = ""
+scope = ""

--- a/addons/block_code/blocks/math/vector2_y.tres
+++ b/addons/block_code/blocks/math/vector2_y.tres
@@ -11,7 +11,7 @@ category = "Math"
 type = 3
 variant_type = 3
 display_template = "y of {vector2: VECTOR2}"
-code_template = "({vector2}).y"
+code_template = "{vector2}.y"
 defaults = {
 "vector2": Vector2(0, 0)
 }


### PR DESCRIPTION
Adds the `x of (Vector2)` and `y of (Vector2)` blocks. The blocks are not ordered in the block picker

Helping with the issue https://github.com/endlessm/godot-block-coding/issues/248#issue-2575803628

![image](https://github.com/user-attachments/assets/36ca839e-db37-4238-9a21-df77dfd24769)

![image](https://github.com/user-attachments/assets/1e585f75-899c-42ab-9b39-20dcc56cd561)

- Using the `(string1)+(string2)` block adds numbers instead of concatenating. This is probably a feature of the GDScript `+` operator. A separate concatenation block or a number to string block may need to be added