### PR TITLE
Allow using Vector2 in boolean context

### DIFF
--- a/addons/block_code/types/types.gd
+++ b/addons/block_code/types/types.gd
@@ -41,6 +41,7 @@ const cast_relationships = [
 	[TYPE_FLOAT, TYPE_STRING, "str(%s)"],
 	[TYPE_COLOR, TYPE_STRING, "str(%s)"],
 	[TYPE_VECTOR2, TYPE_STRING, "str(%s)"],
+	[TYPE_VECTOR2, TYPE_BOOL, "%s"],
 ]
 
 # Directed graph, edges are CastGraphEdge


### PR DESCRIPTION
A vector is truthy if either component is non-zero, and falsey if both components are zero.