### PR TITLE
blocks: Add remove node block

### DIFF
--- a/addons/block_code/blocks/lifecycle/queue_free_node.tres
+++ b/addons/block_code/blocks/lifecycle/queue_free_node.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3 uid="uid://d31lkxkm5lww7"]
+
+[ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_75fle"]
+
+[resource]
+script = ExtResource("1_75fle")
+name = &"queue_free_node"
+target_node_class = ""
+description = "Queues the given node to be deleted at the end of the current frame"
+category = "Lifecycle"
+type = 2
+variant_type = 0
+display_template = "remove {node: OBJECT}"
+code_template = "{node}.queue_free()"
+defaults = {}
+signal_name = ""
+scope = ""


### PR DESCRIPTION
When spawning nodes with SimpleSpawner, you likely need a way to delete the node eventually. While you can call queue_free on a node using the call_method_node block, it's nicer to hide the queue_free detail behind a block.