### PR TITLE
Physics process block

### DIFF
--- a/addons/block_code/blocks/lifecycle/physics_process.tres
+++ b/addons/block_code/blocks/lifecycle/physics_process.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" load_steps=2 format=3 uid="uid://bc8ves8k3jwy8"]
+
+[ext_resource type="Script" path="res://addons/block_code/code_generation/block_definition.gd" id="1_gdr77"]
+
+[resource]
+script = ExtResource("1_gdr77")
+name = &"physics_process"
+target_node_class = ""
+description = "Attached blocks will be executed before each physics step"
+category = "Lifecycle"
+type = 1
+variant_type = 0
+display_template = "every physics step"
+code_template = "func _physics_process(delta):"
+defaults = {}
+signal_name = ""
+scope = ""


### PR DESCRIPTION
Adds the `every physics step` block. The [documentation](https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html#physics-process-callback) says that the `_physics_process()` function is native to every node and is called before each physics step. The debugger displays a warning because `delta` is unused

Helping with the issue https://github.com/endlessm/godot-block-coding/issues/261#issue-2580370059 (This might not fix the issue if the `delta` parameter is needed)
![image](https://github.com/user-attachments/assets/b410f2fa-8005-4798-8f87-f82ed6d305a4)

![image](https://github.com/user-attachments/assets/95684f26-c270-40de-a443-5885c6cc0136)

- Should the description be more informative?