### PR TITLE
SimpleSpawner: Rename frequency to period

### DIFF
--- a/addons/block_code/examples/spawner/spawner.tscn
+++ b/addons/block_code/examples/spawner/spawner.tscn
@@ -37,7 +37,7 @@ arguments = {
 
 [sub_resource type="Resource" id="Resource_uv0fo"]
 script = ExtResource("7_cykhe")
-name = &"simplespawner_get_spawn_frequency"
+name = &"simplespawner_get_spawn_period"
 arguments = {}
 
 [sub_resource type="Resource" id="Resource_l45hk"]
@@ -50,10 +50,10 @@ arguments = {
 
 [sub_resource type="Resource" id="Resource_6g0ng"]
 script = ExtResource("6_dv2kl")
-name = &"simplespawner_set_spawn_frequency"
+name = &"simplespawner_set_spawn_period"
 children = Array[ExtResource("6_dv2kl")]([])
 arguments = {
-"new_frequency": SubResource("Resource_l45hk")
+"new_period": SubResource("Resource_l45hk")
 }
 
 [sub_resource type="Resource" id="Resource_ke4bk"]
@@ -74,7 +74,7 @@ arguments = {
 
 [sub_resource type="Resource" id="Resource_ih8lj"]
 script = ExtResource("7_cykhe")
-name = &"simplespawner_get_spawn_frequency"
+name = &"simplespawner_get_spawn_period"
 arguments = {}
 
 [sub_resource type="Resource" id="Resource_rfxul"]
@@ -87,10 +87,10 @@ arguments = {
 
 [sub_resource type="Resource" id="Resource_2rqfa"]
 script = ExtResource("6_dv2kl")
-name = &"simplespawner_set_spawn_frequency"
+name = &"simplespawner_set_spawn_period"
 children = Array[ExtResource("6_dv2kl")]([])
 arguments = {
-"new_frequency": SubResource("Resource_rfxul")
+"new_period": SubResource("Resource_rfxul")
 }
 
 [sub_resource type="Resource" id="Resource_movu5"]
@@ -194,9 +194,9 @@ func _ready():
 
 func _process(delta):
 	if (Input.is_action_just_pressed('ui_right')):
-		do_set_spawn_frequency(((spawn_frequency) - 0.1))
+		spawn_period = ((spawn_period) - 0.1)
 	elif (Input.is_action_just_pressed('ui_left')):
-		do_set_spawn_frequency(((spawn_frequency) + 0.1))
+		spawn_period = ((spawn_period) + 0.1)
 	elif (Input.is_action_just_pressed('ui_up')):
 		if (is_spawning()):
 			spawn_stop()
@@ -216,7 +216,7 @@ version = 0
 position = Vector2(103, 128)
 script = ExtResource("1_g2l2s")
 scenes = Array[PackedScene]([ExtResource("2_d0h86"), ExtResource("3_tt12o")])
-spawn_frequency = 0.6
+spawn_period = 0.6
 spawn_limit = 5
 
 [node name="BlockCode" type="Node" parent="SimpleSpawner"]

--- a/addons/block_code/simple_spawner/simple_spawner.gd
+++ b/addons/block_code/simple_spawner/simple_spawner.gd
@@ -23,8 +23,8 @@ enum LimitBehavior { REPLACE, NO_SPAWN }
 
 ## The period of time in seconds to spawn another component. If zero, they won't spawn
 ## automatically. Use the "Spawn" block.
-@export_range(0.0, 10.0, 0.1, "or_greater", "suffix:s") var spawn_frequency: float = 0.0:
-	set = _set_spawn_fraquency
+@export_range(0.0, 10.0, 0.1, "or_greater", "suffix:s") var spawn_period: float = 0.0:
+	set = _set_spawn_period
 
 ## How many spawned scenes are allowed. If zero, there is no limit.
 @export_range(0, 50, 0.1, "or_greater", "suffix:scenes") var spawn_limit: int = 50
@@ -53,20 +53,20 @@ func _remove_oldest_spawned():
 		spawned.get_parent().remove_child(spawned)
 
 
-func _set_spawn_fraquency(new_frequency: float):
-	spawn_frequency = new_frequency
+func _set_spawn_period(new_period: float):
+	spawn_period = new_period
 	if not _timer or not is_instance_valid(_timer):
 		return
-	_timer.wait_time = spawn_frequency
+	_timer.wait_time = spawn_period
 
 
 func spawn_start():
-	if spawn_frequency == 0.0:
+	if spawn_period == 0.0:
 		return
 	if not _timer or not is_instance_valid(_timer):
 		_timer = Timer.new()
 		add_child(_timer)
-		_timer.wait_time = spawn_frequency
+		_timer.wait_time = spawn_period
 		_timer.timeout.connect(spawn_once)
 	_timer.start()
 	spawn_once.call_deferred()
@@ -105,10 +105,6 @@ func spawn_once():
 		SpawnParent.SCENE:
 			get_tree().current_scene.add_child(spawned)
 			spawned.position = global_position
-
-
-func do_set_spawn_frequency(new_frequency: float):
-	_set_spawn_fraquency(new_frequency)
 
 
 static func setup_custom_blocks():
@@ -153,22 +149,22 @@ static func setup_custom_blocks():
 	block_list.append(block_definition)
 
 	block_definition = BlockDefinition.new()
-	block_definition.name = &"simplespawner_set_spawn_frequency"
+	block_definition.name = &"simplespawner_set_spawn_period"
 	block_definition.target_node_class = _class_name
 	block_definition.category = "Lifecycle | Spawn"
 	block_definition.type = Types.BlockType.STATEMENT
-	block_definition.display_template = "set spawn frequency to {new_frequency: FLOAT}"
-	block_definition.code_template = "do_set_spawn_frequency({new_frequency})"
+	block_definition.display_template = "set spawn period to {new_period: FLOAT}"
+	block_definition.code_template = "spawn_period = {new_period}"
 	block_list.append(block_definition)
 
 	block_definition = BlockDefinition.new()
-	block_definition.name = &"simplespawner_get_spawn_frequency"
+	block_definition.name = &"simplespawner_get_spawn_period"
 	block_definition.target_node_class = _class_name
 	block_definition.category = "Lifecycle | Spawn"
 	block_definition.type = Types.BlockType.VALUE
 	block_definition.variant_type = TYPE_FLOAT
-	block_definition.display_template = "spawn frequency"
-	block_definition.code_template = "spawn_frequency"
+	block_definition.display_template = "spawn period"
+	block_definition.code_template = "spawn_period"
 	block_list.append(block_definition)
 
 	BlocksCatalog.add_custom_blocks(_class_name, block_list, [], {})

--- a/addons/block_code/simple_spawner/simple_spawner.gd
+++ b/addons/block_code/simple_spawner/simple_spawner.gd
@@ -23,11 +23,11 @@ enum LimitBehavior { REPLACE, NO_SPAWN }
 
 ## The period of time in seconds to spawn another component. If zero, they won't spawn
 ## automatically. Use the "Spawn" block.
-@export_range(0.0, 10.0, 0.1, "or_greater") var spawn_frequency: float = 0.0:
+@export_range(0.0, 10.0, 0.1, "or_greater", "suffix:s") var spawn_frequency: float = 0.0:
 	set = _set_spawn_fraquency
 
 ## How many spawned scenes are allowed. If zero, there is no limit.
-@export_range(0, 50, 0.1, "or_greater") var spawn_limit: int = 50
+@export_range(0, 50, 0.1, "or_greater", "suffix:scenes") var spawn_limit: int = 50
 
 ## What happens when the limit is reached and a new spawn is attempted:
 ## - Replace: Remove the oldest spawned scene and spawn a new one.


### PR DESCRIPTION
This property is the time, in seconds, to wait between spawning scenes. This is a period/interval/wavelength, not a frequency, which would be measured in Hz, or 1/seconds.

Adjust the name of the property and its documentation.

The instances of “frequency” that I have not changed are in the example scene's on-screen documentation. In this case it was actually used correctly: the keyboard action to increase the frequency reduces the property which is now called period, and the decrease action respectively increases the period.

I also added an annotation I learned yesterday to put units in the inspector slider for spawn period and spawn limit.

![Screenshot from 2024-10-14 11-21-18](https://github.com/user-attachments/assets/bb905375-9b23-49f5-b36d-eec984e089ea)
