### PR TITLE
blocks: Remove extra newlines from entry blocks

### DIFF
--- a/addons/block_code/blocks/communication/area2d_on_entered.tres
+++ b/addons/block_code/blocks/communication/area2d_on_entered.tres
@@ -11,8 +11,7 @@ category = "Communication | Methods"
 type = 1
 variant_type = 0
 display_template = "when this node collides with [something: OBJECT]"
-code_template = "func _on_body_entered(something: Node2D):
-"
+code_template = "func _on_body_entered(something: Node2D):"
 defaults = {}
 signal_name = "body_entered"
 scope = ""

--- a/addons/block_code/blocks/communication/area2d_on_exited.tres
+++ b/addons/block_code/blocks/communication/area2d_on_exited.tres
@@ -11,8 +11,7 @@ category = "Communication | Methods"
 type = 1
 variant_type = 0
 display_template = "when this node stops colliding with [something: OBJECT]"
-code_template = "func _on_body_exited(something: Node2D):
-"
+code_template = "func _on_body_exited(something: Node2D):"
 defaults = {}
 signal_name = "body_exited"
 scope = ""

--- a/addons/block_code/blocks/communication/rigidbody2d_on_entered.tres
+++ b/addons/block_code/blocks/communication/rigidbody2d_on_entered.tres
@@ -11,8 +11,7 @@ category = "Communication | Methods"
 type = 1
 variant_type = 0
 display_template = "when this node collides with [something: OBJECT]"
-code_template = "func _on_body_entered(something: Node2D):
-"
+code_template = "func _on_body_entered(something: Node2D):"
 defaults = {}
 signal_name = "body_entered"
 scope = ""

--- a/addons/block_code/blocks/communication/rigidbody2d_on_exited.tres
+++ b/addons/block_code/blocks/communication/rigidbody2d_on_exited.tres
@@ -11,8 +11,7 @@ category = "Communication | Methods"
 type = 1
 variant_type = 0
 display_template = "when this node stops colliding with [something: OBJECT]"
-code_template = "func _on_body_exited(something: Node2D):
-"
+code_template = "func _on_body_exited(something: Node2D):"
 defaults = {}
 signal_name = "body_exited"
 scope = ""

--- a/tests/test_code_generation.gd
+++ b/tests/test_code_generation.gd
@@ -232,7 +232,6 @@ func test_signal_script():
 				body_entered.connect(_on_body_entered)
 
 			func _on_body_entered(something: Node2D):
-
 				print('Body entered!')
 
 			"""


### PR DESCRIPTION
Entry blocks already add a trailing newline, so there's no need to include one in the code template. See the ready, process and define_method blocks, for example. Having one doesn't cause any harm, but it does make the generated code uglier.