### PR TITLE
simple_nodes: Add SimpleEnding node

### DIFF
--- a/addons/block_code/simple_nodes/simple_ending/simple_ending.gd
+++ b/addons/block_code/simple_nodes/simple_ending/simple_ending.gd
@@ -1,0 +1,89 @@
+@tool
+class_name SimpleEnding
+extends Label
+
+const BlockDefinition = preload("res://addons/block_code/code_generation/block_definition.gd")
+const BlocksCatalog = preload("res://addons/block_code/code_generation/blocks_catalog.gd")
+const OptionData = preload("res://addons/block_code/code_generation/option_data.gd")
+const Types = preload("res://addons/block_code/types/types.gd")
+
+## The message that will be shown when the player wins the game.
+@export var win_message: String = "YOU WIN!"
+
+## The message that will be shown when the player loses the game.
+@export var lose_message: String = "GAME OVER"
+
+
+func game_over(result: String):
+	match result:
+		"WIN":
+			text = win_message
+		"LOSE":
+			text = lose_message
+		_:
+			text = ""
+			push_warning('Unrecognized game result "%s"' % result)
+
+
+func reset():
+	text = ""
+
+
+func _ready():
+	simple_setup()
+
+
+func simple_setup():
+	if not label_settings:
+		label_settings = LabelSettings.new()
+		label_settings.font_size = 200
+	horizontal_alignment = HorizontalAlignment.HORIZONTAL_ALIGNMENT_CENTER
+	vertical_alignment = VerticalAlignment.VERTICAL_ALIGNMENT_CENTER
+
+
+func _enter_tree():
+	# In the editor, show the win message so that adjusting the label
+	# properties is visible. Otherwise, clear the text when entering the tree
+	# so that the label text persisted in the scene file isn't shown.
+	#
+	# Normally this would be done in _ready, but a block script might override
+	# that and simple_setup is too late.
+	if Engine.is_editor_hint():
+		text = win_message
+	else:
+		text = ""
+
+
+func get_custom_class():
+	return "SimpleEnding"
+
+
+static func setup_custom_blocks():
+	var _class_name = "SimpleEnding"
+	var block_list: Array[BlockDefinition] = []
+	var block_definition: BlockDefinition
+
+	block_definition = BlockDefinition.new()
+	block_definition.name = &"simpleending_game_over"
+	block_definition.target_node_class = _class_name
+	block_definition.category = "Lifecycle | Game"
+	block_definition.type = Types.BlockType.STATEMENT
+	block_definition.display_template = "game over {result: STRING}"
+	block_definition.code_template = "game_over({result})"
+	block_definition.defaults = {
+		"result": OptionData.new(["WIN", "LOSE"]),
+	}
+	block_definition.description = "Show the game over label with the win or lose message."
+	block_list.append(block_definition)
+
+	block_definition = BlockDefinition.new()
+	block_definition.name = &"simpleending_reset"
+	block_definition.target_node_class = _class_name
+	block_definition.category = "Lifecycle | Game"
+	block_definition.type = Types.BlockType.STATEMENT
+	block_definition.display_template = "reset game over"
+	block_definition.code_template = "reset()"
+	block_definition.description = "Reset the game over label."
+	block_list.append(block_definition)
+
+	BlocksCatalog.add_custom_blocks(_class_name, block_list)

--- a/addons/block_code/ui/constants.gd
+++ b/addons/block_code/ui/constants.gd
@@ -22,6 +22,11 @@ const BUILTIN_CATEGORIES_PROPS: Dictionary = {
 		"color": Color("ec3b59"),
 		"order": 10,
 	},
+	"Lifecycle | Game":
+	{
+		"color": Color("ec3b59"),
+		"order": 12,
+	},
 	"Lifecycle | Spawn":
 	{
 		"color": Color("ec3b59"),


### PR DESCRIPTION
This provides a label that displays either a win or lose message along with blocks to set or clear the label during the game. Label is inherited directly so that all the label properties are available in the inspector.

https://phabricator.endlessm.com/T35661