### PR TITLE
SimpleSpawner: Rename frequency to period (with backwards compatibility)

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -27,7 +27,7 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        godot-version: [4.2.2, 4.3.0]
+        godot-version: [4.3.0]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/addons/block_code/blocks/communication/add_node_to_group.tres
+++ b/addons/block_code/blocks/communication/add_node_to_group.tres
@@ -25,3 +25,4 @@ defaults = {
 signal_name = ""
 scope = ""
 extension_script = ExtResource("1_p83c7")
+hidden = false

--- a/addons/block_code/blocks/communication/add_to_group.tres
+++ b/addons/block_code/blocks/communication/add_to_group.tres
@@ -25,3 +25,4 @@ defaults = {
 signal_name = ""
 scope = ""
 extension_script = ExtResource("2_42ixf")
+hidden = false

--- a/addons/block_code/blocks/communication/call_method_group.tres
+++ b/addons/block_code/blocks/communication/call_method_group.tres
@@ -25,3 +25,4 @@ defaults = {
 signal_name = ""
 scope = ""
 extension_script = ExtResource("1_of577")
+hidden = false

--- a/addons/block_code/blocks/communication/get_node.tres
+++ b/addons/block_code/blocks/communication/get_node.tres
@@ -25,3 +25,4 @@ defaults = {
 signal_name = ""
 scope = ""
 extension_script = ExtResource("1_we5wl")
+hidden = false

--- a/addons/block_code/blocks/communication/is_in_group.tres
+++ b/addons/block_code/blocks/communication/is_in_group.tres
@@ -25,3 +25,4 @@ defaults = {
 signal_name = ""
 scope = ""
 extension_script = ExtResource("2_o165d")
+hidden = false

--- a/addons/block_code/blocks/communication/is_node_in_group.tres
+++ b/addons/block_code/blocks/communication/is_node_in_group.tres
@@ -25,3 +25,4 @@ defaults = {
 signal_name = ""
 scope = ""
 extension_script = ExtResource("1_r4prw")
+hidden = false

--- a/addons/block_code/blocks/communication/remove_from_group.tres
+++ b/addons/block_code/blocks/communication/remove_from_group.tres
@@ -25,3 +25,4 @@ defaults = {
 signal_name = ""
 scope = ""
 extension_script = ExtResource("1_i50fw")
+hidden = false

--- a/addons/block_code/blocks/communication/remove_node_from_group.tres
+++ b/addons/block_code/blocks/communication/remove_node_from_group.tres
@@ -25,3 +25,4 @@ defaults = {
 signal_name = ""
 scope = ""
 extension_script = ExtResource("1_h3lhb")
+hidden = false

--- a/addons/block_code/blocks/graphics/animationplayer_play.tres
+++ b/addons/block_code/blocks/graphics/animationplayer_play.tres
@@ -43,3 +43,4 @@ defaults = {
 signal_name = ""
 scope = ""
 extension_script = ExtResource("2_7ymgi")
+hidden = false

--- a/addons/block_code/blocks/input/is_input_actioned.tres
+++ b/addons/block_code/blocks/input/is_input_actioned.tres
@@ -25,3 +25,4 @@ defaults = {
 signal_name = ""
 scope = ""
 extension_script = ExtResource("2_h11b7")
+hidden = false

--- a/addons/block_code/blocks/logic/compare.tres
+++ b/addons/block_code/blocks/logic/compare.tres
@@ -25,3 +25,4 @@ defaults = {
 }
 signal_name = ""
 scope = ""
+hidden = false

--- a/addons/block_code/blocks/sounds/pause_continue_sound.tres
+++ b/addons/block_code/blocks/sounds/pause_continue_sound.tres
@@ -28,3 +28,4 @@ defaults = {
 }
 signal_name = ""
 scope = ""
+hidden = false

--- a/addons/block_code/code_generation/block_definition.gd
+++ b/addons/block_code/code_generation/block_definition.gd
@@ -30,6 +30,11 @@ const FORMAT_STRING_PATTERN = "\\[(?<out_parameter>[^\\]]+)\\]|\\{(?<in_paramete
 
 @export var extension_script: GDScript
 
+## If true, do not show this block in the picker. This allows a block
+## definition to be kept for backwards-compatibility with existing block
+## programs, but not available for use in new programs.
+@export var hidden: bool = false
+
 static var _display_template_regex := RegEx.create_from_string(FORMAT_STRING_PATTERN)
 
 

--- a/addons/block_code/simple_spawner/simple_spawner.gd
+++ b/addons/block_code/simple_spawner/simple_spawner.gd
@@ -23,11 +23,11 @@ enum LimitBehavior { REPLACE, NO_SPAWN }
 
 ## The period of time in seconds to spawn another component. If zero, they won't spawn
 ## automatically. Use the "Spawn" block.
-@export_range(0.0, 10.0, 0.1, "or_greater") var spawn_frequency: float = 0.0:
+@export_range(0.0, 10.0, 0.1, "or_greater", "suffix:s") var spawn_frequency: float = 0.0:
 	set = _set_spawn_fraquency
 
 ## How many spawned scenes are allowed. If zero, there is no limit.
-@export_range(0, 50, 0.1, "or_greater") var spawn_limit: int = 50
+@export_range(0, 50, 0.1, "or_greater", "suffix:scenes") var spawn_limit: int = 50
 
 ## What happens when the limit is reached and a new spawn is attempted:
 ## - Replace: Remove the oldest spawned scene and spawn a new one.

--- a/addons/block_code/ui/picker/picker.gd
+++ b/addons/block_code/ui/picker/picker.gd
@@ -73,7 +73,7 @@ func _update_block_components():
 		block_category_display.hide()
 
 	for category in block_categories:
-		var block_definitions := _context.block_script.get_blocks_in_category(category)
+		var block_definitions = _context.block_script.get_blocks_in_category(category).filter(func(block): return not block.hidden)
 		var order_override = CATEGORY_ORDER_OVERRIDE.get(category.name)
 		if order_override:
 			block_definitions.sort_custom(_sort_blocks_by_list_order.bind(order_override))

--- a/asset-template.json.hb
+++ b/asset-template.json.hb
@@ -2,7 +2,7 @@
   "title": "Block Coding",
   "description": "Create games using a high-level, block-based visual programming language.\r\n\r\nIntended as an educational tool for learners in the earlier stages of their journey towards becoming game developers. This plugin lets you create your first games with high-level blocks, avoiding the immediate need to learn to code in GDScript. Building games in this way provides a gentle introduction to programming concepts and allows you to focus your efforts on becoming familiar with the rest of the Godot Editor UI.",
   "category_id": "5",
-  "godot_version": "4.2",
+  "godot_version": "4.3",
   "version_string": "{{ context.release.name }}",
   "cost": "MIT",
   "support_level": "community",


### PR DESCRIPTION
This is an alternative to:

- #272

with backwards compatibility with existing block programs. It roughly implements @dbnicholson's suggestion in https://github.com/endlessm/godot-block-coding/pull/272#pullrequestreview-2369649749:

> An issue here is backwards compatibility. Changing the exported variable and block definition names will break any scene using SimpleSpawner (as implied by the changes in the example spawner scene). While we have not committed to any backwards compatibility, I feel like we shouldn't put this in a 0.7 patch release.
> 
> I think it would be possible to maintain compatibility in a couple ways.
> 
> 1. Keep an unexported `spawn_frequency` that wraps `spawn_period` with getters and setters.

Actually it has to be exported; otherwise values in existing `.tscn` files are not set. I learned about the [`@export_storage`](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_exports.html#export-storage) annotation, added in Godot 4.3, which does what we want here. However that does mean bumping the minimum supported Godot version. And also it means that both properties will be saved in scenes – not only existing scenes which instantiated SimpleSpawner and set the old property, but also those that set the new name.

> 2. Duplicate the block definitions with the old names. However, that would make both blocks show up in the picker. You'd probably need to add some type of `hidden` block definition attribute. Or you could add an `aliases` block definition attribute that was used for lookup when loading.

I took the `hidden` path. But having written it, I think the result is kind of ugly. Maybe `aliases` would be better.

It was interesting to learn some things about properties, but having written all this I kind of think we should just go with #272: make the destructive change and call the next release 0.8.0. I'm interested in other opinions though.