### PR TITLE
SimpleSpawner: Rename frequency to period (with partial backwards compatibility)

### DIFF
--- a/addons/block_code/blocks/communication/add_node_to_group.tres
+++ b/addons/block_code/blocks/communication/add_node_to_group.tres
@@ -12,6 +12,7 @@ items = []
 [resource]
 script = ExtResource("1_5qal7")
 name = &"add_node_to_group"
+aliases = Array[StringName]([])
 target_node_class = ""
 description = "Add the node into the group"
 category = "Communication | Groups"

--- a/addons/block_code/blocks/communication/add_to_group.tres
+++ b/addons/block_code/blocks/communication/add_to_group.tres
@@ -12,6 +12,7 @@ items = []
 [resource]
 script = ExtResource("1_bcm71")
 name = &"add_to_group"
+aliases = Array[StringName]([])
 target_node_class = ""
 description = "Add this node into the group"
 category = "Communication | Groups"

--- a/addons/block_code/blocks/communication/call_method_group.tres
+++ b/addons/block_code/blocks/communication/call_method_group.tres
@@ -12,6 +12,7 @@ items = []
 [resource]
 script = ExtResource("1_mlm68")
 name = &"call_method_group"
+aliases = Array[StringName]([])
 target_node_class = ""
 description = "Calls the method/function on each member of the given group"
 category = "Communication | Methods"

--- a/addons/block_code/blocks/communication/get_node.tres
+++ b/addons/block_code/blocks/communication/get_node.tres
@@ -12,6 +12,7 @@ items = []
 [resource]
 script = ExtResource("1_d60g7")
 name = &"get_node"
+aliases = Array[StringName]([])
 target_node_class = ""
 description = "Get the node at the given path"
 category = "Communication | Nodes"

--- a/addons/block_code/blocks/communication/is_in_group.tres
+++ b/addons/block_code/blocks/communication/is_in_group.tres
@@ -12,6 +12,7 @@ items = []
 [resource]
 script = ExtResource("1_tjyq5")
 name = &"is_in_group"
+aliases = Array[StringName]([])
 target_node_class = ""
 description = "Is this node in the group"
 category = "Communication | Groups"

--- a/addons/block_code/blocks/communication/is_node_in_group.tres
+++ b/addons/block_code/blocks/communication/is_node_in_group.tres
@@ -12,6 +12,7 @@ items = []
 [resource]
 script = ExtResource("1_5krrs")
 name = &"is_node_in_group"
+aliases = Array[StringName]([])
 target_node_class = ""
 description = "Is the node in the group"
 category = "Communication | Groups"

--- a/addons/block_code/blocks/communication/remove_from_group.tres
+++ b/addons/block_code/blocks/communication/remove_from_group.tres
@@ -12,6 +12,7 @@ items = []
 [resource]
 script = ExtResource("1_cdwef")
 name = &"remove_from_group"
+aliases = Array[StringName]([])
 target_node_class = ""
 description = "Remove this node from the group"
 category = "Communication | Groups"

--- a/addons/block_code/blocks/communication/remove_node_from_group.tres
+++ b/addons/block_code/blocks/communication/remove_node_from_group.tres
@@ -12,6 +12,7 @@ items = []
 [resource]
 script = ExtResource("1_pec24")
 name = &"remove_node_from_group"
+aliases = Array[StringName]([])
 target_node_class = ""
 description = "Remove the node from the group"
 category = "Communication | Groups"

--- a/addons/block_code/blocks/graphics/animationplayer_play.tres
+++ b/addons/block_code/blocks/graphics/animationplayer_play.tres
@@ -22,6 +22,7 @@ items = ["until done", "in the background"]
 [resource]
 script = ExtResource("1_emeuv")
 name = &"animationplayer_play"
+aliases = Array[StringName]([])
 target_node_class = "AnimationPlayer"
 description = "Play the animation."
 category = "Graphics | Animation"

--- a/addons/block_code/blocks/input/is_input_actioned.tres
+++ b/addons/block_code/blocks/input/is_input_actioned.tres
@@ -12,6 +12,7 @@ items = ["pressed", "just_pressed", "just_released"]
 [resource]
 script = ExtResource("1_rprh7")
 name = &"is_input_actioned"
+aliases = Array[StringName]([])
 target_node_class = ""
 description = "True if the specified input action has been pressed or released."
 category = "Input"

--- a/addons/block_code/blocks/logic/compare.tres
+++ b/addons/block_code/blocks/logic/compare.tres
@@ -11,6 +11,7 @@ items = ["==", ">", "<", ">=", "<=", "!="]
 [resource]
 script = ExtResource("1_wp40r")
 name = &"compare"
+aliases = Array[StringName]([])
 target_node_class = ""
 description = ""
 category = "Logic | Comparison"

--- a/addons/block_code/blocks/sounds/pause_continue_sound.tres
+++ b/addons/block_code/blocks/sounds/pause_continue_sound.tres
@@ -11,6 +11,7 @@ items = ["pause", "continue"]
 [resource]
 script = ExtResource("1_q04gm")
 name = &"pause_continue_sound"
+aliases = Array[StringName]([])
 target_node_class = ""
 description = "Pause/Continue the audio stream"
 category = "Sounds"

--- a/addons/block_code/code_generation/block_definition.gd
+++ b/addons/block_code/code_generation/block_definition.gd
@@ -6,6 +6,7 @@ const Types = preload("res://addons/block_code/types/types.gd")
 const FORMAT_STRING_PATTERN = "\\[(?<out_parameter>[^\\]]+)\\]|\\{(?<in_parameter>[^}]+)\\}|(?<label>[^\\{\\[]+)"
 
 @export var name: StringName
+@export var aliases: Array[StringName]
 
 ## The target node. Leaving this empty the block is considered a general block
 ## (for any node).

--- a/addons/block_code/serialization/block_script_serialization.gd
+++ b/addons/block_code/serialization/block_script_serialization.gd
@@ -101,7 +101,7 @@ func get_block_definition(block_name: String) -> BlockDefinition:
 
 func _get_base_block_definition(block_name: String) -> BlockDefinition:
 	for block_definition in _available_blocks:
-		if block_definition.name == block_name:
+		if block_definition.name == block_name or block_name in block_definition.aliases:
 			return block_definition
 	return null
 

--- a/addons/block_code/simple_spawner/simple_spawner.gd
+++ b/addons/block_code/simple_spawner/simple_spawner.gd
@@ -23,8 +23,8 @@ enum LimitBehavior { REPLACE, NO_SPAWN }
 
 ## The period of time in seconds to spawn another component. If zero, they won't spawn
 ## automatically. Use the "Spawn" block.
-@export_range(0.0, 10.0, 0.1, "or_greater", "suffix:s") var spawn_frequency: float = 0.0:
-	set = _set_spawn_fraquency
+@export_range(0.0, 10.0, 0.1, "or_greater", "suffix:s") var spawn_period: float = 0.0:
+	set = _set_spawn_period
 
 ## How many spawned scenes are allowed. If zero, there is no limit.
 @export_range(0, 50, 0.1, "or_greater", "suffix:scenes") var spawn_limit: int = 50
@@ -53,20 +53,20 @@ func _remove_oldest_spawned():
 		spawned.get_parent().remove_child(spawned)
 
 
-func _set_spawn_fraquency(new_frequency: float):
-	spawn_frequency = new_frequency
+func _set_spawn_period(new_period: float):
+	spawn_period = new_period
 	if not _timer or not is_instance_valid(_timer):
 		return
-	_timer.wait_time = spawn_frequency
+	_timer.wait_time = spawn_period
 
 
 func spawn_start():
-	if spawn_frequency == 0.0:
+	if spawn_period == 0.0:
 		return
 	if not _timer or not is_instance_valid(_timer):
 		_timer = Timer.new()
 		add_child(_timer)
-		_timer.wait_time = spawn_frequency
+		_timer.wait_time = spawn_period
 		_timer.timeout.connect(spawn_once)
 	_timer.start()
 	spawn_once.call_deferred()
@@ -106,9 +106,9 @@ func spawn_once():
 			get_tree().current_scene.add_child(spawned)
 			spawned.position = global_position
 
-
+## @deprecated: Use [member spawn_period] property
 func do_set_spawn_frequency(new_frequency: float):
-	_set_spawn_fraquency(new_frequency)
+	spawn_period = new_frequency
 
 
 static func setup_custom_blocks():
@@ -159,7 +159,7 @@ static func setup_custom_blocks():
 	block_definition.category = "Lifecycle | Spawn"
 	block_definition.type = Types.BlockType.STATEMENT
 	block_definition.display_template = "set spawn period to {new_period: FLOAT} seconds"
-	block_definition.code_template = "spawn_frequency = {new_period})"
+	block_definition.code_template = "spawn_period = {new_period})"
 	block_list.append(block_definition)
 
 	block_definition = BlockDefinition.new()
@@ -170,7 +170,7 @@ static func setup_custom_blocks():
 	block_definition.type = Types.BlockType.VALUE
 	block_definition.variant_type = TYPE_FLOAT
 	block_definition.display_template = "spawn period"
-	block_definition.code_template = "spawn_frequency"
+	block_definition.code_template = "spawn_period"
 	block_list.append(block_definition)
 
 	BlocksCatalog.add_custom_blocks(_class_name, block_list, [], {})

--- a/addons/block_code/simple_spawner/simple_spawner.gd
+++ b/addons/block_code/simple_spawner/simple_spawner.gd
@@ -153,21 +153,23 @@ static func setup_custom_blocks():
 	block_list.append(block_definition)
 
 	block_definition = BlockDefinition.new()
-	block_definition.name = &"simplespawner_set_spawn_frequency"
+	block_definition.name = &"simplespawner_set_spawn_period"
+	block_definition.aliases = [&"simplespawner_set_spawn_frequency"]
 	block_definition.target_node_class = _class_name
 	block_definition.category = "Lifecycle | Spawn"
 	block_definition.type = Types.BlockType.STATEMENT
-	block_definition.display_template = "set spawn frequency to {new_frequency: FLOAT}"
-	block_definition.code_template = "do_set_spawn_frequency({new_frequency})"
+	block_definition.display_template = "set spawn period to {new_period: FLOAT} seconds"
+	block_definition.code_template = "spawn_frequency = {new_period})"
 	block_list.append(block_definition)
 
 	block_definition = BlockDefinition.new()
-	block_definition.name = &"simplespawner_get_spawn_frequency"
+	block_definition.name = &"simplespawner_get_spawn_period"
+	block_definition.aliases = [&"simplespawner_get_spawn_frequency"]
 	block_definition.target_node_class = _class_name
 	block_definition.category = "Lifecycle | Spawn"
 	block_definition.type = Types.BlockType.VALUE
 	block_definition.variant_type = TYPE_FLOAT
-	block_definition.display_template = "spawn frequency"
+	block_definition.display_template = "spawn period"
 	block_definition.code_template = "spawn_frequency"
 	block_list.append(block_definition)
 

--- a/addons/block_code/simple_spawner/simple_spawner.gd
+++ b/addons/block_code/simple_spawner/simple_spawner.gd
@@ -23,11 +23,11 @@ enum LimitBehavior { REPLACE, NO_SPAWN }
 
 ## The period of time in seconds to spawn another component. If zero, they won't spawn
 ## automatically. Use the "Spawn" block.
-@export_range(0.0, 10.0, 0.1, "or_greater") var spawn_frequency: float = 0.0:
+@export_range(0.0, 10.0, 0.1, "or_greater", "suffix:s") var spawn_frequency: float = 0.0:
 	set = _set_spawn_fraquency
 
 ## How many spawned scenes are allowed. If zero, there is no limit.
-@export_range(0, 50, 0.1, "or_greater") var spawn_limit: int = 50
+@export_range(0, 50, 0.1, "or_greater", "suffix:scenes") var spawn_limit: int = 50
 
 ## What happens when the limit is reached and a new spawn is attempted:
 ## - Replace: Remove the oldest spawned scene and spawn a new one.


### PR DESCRIPTION
Like #283 but:

1. The renamed blocks have aliases, rather than being copy-pasted. However this doesn't work as desired because the parameter is renamed and so existing programs are broken by updating; and adding named parameter aliases seems a step too far.
2. No compat alias is added for the property itself

I'm just pushing this for reference in case we ever did want to add block aliases but I'll not work further on this.