### PR TITLE
Include type in tooltip

### DIFF
--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -214,7 +214,13 @@ func _to_string():
 
 
 func _get_tooltip(at_position: Vector2) -> String:
-	return definition.description if definition else ""
+	if not definition:
+		return ""
+
+	if definition.variant_type == Variant.Type.TYPE_NIL:
+		return definition.description
+
+	return "{description}\n\nType: [b]{type}[/b]".format({"description": definition.description, "type": type_string(definition.variant_type)})
 
 
 func _make_custom_tooltip(for_text) -> Control:


### PR DESCRIPTION
The variant name as a string is appended to the description. If null, then no type is shown

Helping with https://github.com/endlessm/godot-block-coding/issues/271#issue-2583897016
![image](https://github.com/user-attachments/assets/1d3b460a-d108-4eab-9067-2e9de2c707d7)
![image](https://github.com/user-attachments/assets/a98f1440-4d21-4455-84f0-4bed482f95f0)
![image](https://github.com/user-attachments/assets/d8727d49-1b2d-4b81-8cf0-f425d78ef0cb)
![image](https://github.com/user-attachments/assets/e0f82f3a-aca9-46a7-a726-480c22b41b58)
![image](https://github.com/user-attachments/assets/89c4ba7b-e75e-4cb2-9539-159230884461)
![image](https://github.com/user-attachments/assets/1b71c084-fc44-4082-ade4-b6effb65131f)
