### PR TITLE
Simple spawner rotation alt

### DIFF
--- a/addons/block_code/simple_spawner/simple_spawner.gd
+++ b/addons/block_code/simple_spawner/simple_spawner.gd
@@ -1,6 +1,12 @@
 @tool
 class_name SimpleSpawner
 extends Node2D
+## SimpleSpawner node.
+##
+## The scene being spawned is rotated according to this node's global rotation:
+## - If the spawned scene is a RigidBody2D, the linear velocity and constant forces
+##   are rotated according to the SimpleSpawner node global rotation.
+## - If the spawned scene is a Node2D, the rotation is copied from the SimpleSpawner node.
 
 const BlockDefinition = preload("res://addons/block_code/code_generation/block_definition.gd")
 const BlocksCatalog = preload("res://addons/block_code/code_generation/blocks_catalog.gd")
@@ -99,6 +105,12 @@ func spawn_once():
 	var scene: PackedScene = scenes.pick_random()
 	var spawned = scene.instantiate()
 	_spawned_scenes.push_back(spawned)
+	# Rotate the spawned scene according to the SimpleSpawner:
+	if spawned is RigidBody2D:
+		spawned.linear_velocity = spawned.linear_velocity.rotated(global_rotation)
+		spawned.constant_force = spawned.constant_force.rotated(global_rotation)
+	elif spawned is Node2D:
+		spawned.rotate(global_rotation)
 	match spawn_parent:
 		SpawnParent.THIS:
 			add_child(spawned)

--- a/addons/block_code/simple_spawner/simple_spawner.gd
+++ b/addons/block_code/simple_spawner/simple_spawner.gd
@@ -3,6 +3,10 @@ class_name SimpleSpawner
 extends Node2D
 ## SimpleSpawner node.
 ##
+## If multiple spawned scenes are provided, one is picked ramdomly when spawning.
+##
+## Spawned instances are children of the current scene.
+##
 ## The scene being spawned is rotated according to this node's global rotation:
 ## - If the spawned scene is a RigidBody2D, the linear velocity and constant forces
 ##   are rotated according to the SimpleSpawner node global rotation.
@@ -13,19 +17,10 @@ const BlocksCatalog = preload("res://addons/block_code/code_generation/blocks_ca
 const OptionData = preload("res://addons/block_code/code_generation/option_data.gd")
 const Types = preload("res://addons/block_code/types/types.gd")
 
-enum SpawnParent {
-	THIS,  ## Spawned scenes are children of this node
-	SCENE,  ## Spawned scenes are children of the scene
-}
 enum LimitBehavior { REPLACE, NO_SPAWN }
 
 ## The scenes to spawn. If more than one are provided, they will be picked randomly.
 @export var scenes: Array[PackedScene] = []
-
-## The node that the spawned scenes should be a child of. If you want to move
-## the SimpleSpawner without moving the scenes it has already spawned, choose
-## SCENE.
-@export var spawn_parent: SpawnParent
 
 ## The period of time in seconds to spawn another component. If zero, they won't spawn
 ## automatically. Use the "Spawn" block.
@@ -111,12 +106,9 @@ func spawn_once():
 		spawned.constant_force = spawned.constant_force.rotated(global_rotation)
 	elif spawned is Node2D:
 		spawned.rotate(global_rotation)
-	match spawn_parent:
-		SpawnParent.THIS:
-			add_child(spawned)
-		SpawnParent.SCENE:
-			get_tree().current_scene.add_child(spawned)
-			spawned.position = global_position
+	# Add the spawned instance to the current scene:
+	get_tree().current_scene.add_child(spawned)
+	spawned.position = global_position
 
 
 static func setup_custom_blocks():


### PR DESCRIPTION
This is an alternative to https://github.com/endlessm/godot-block-coding/pull/292

Instead of adding yet another property, make the "rotate with spawner" the default. Also remove the "spawn parent" property to leave only the SCENE behavior (as a separate commit).