### PR TITLE
BlockCanvas: Implement drag & drop the node's property from Inspector

### DIFF
--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -92,6 +92,11 @@ func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
 
 
 func _drop_data(at_position: Vector2, data: Variant) -> void:
+	if data["type"] == "nodes":
+		_drop_node(at_position, data)
+
+
+func _drop_node(at_position: Vector2, data: Variant) -> void:
 	var abs_path: NodePath = data.get("nodes", []).pop_back()
 	if abs_path == null:
 		return


### PR DESCRIPTION
Dragging the node's property from Inspector shows the object's type as "obj_property". So, allow the "obj_property" type in _can_drop_data() and handle it in _drop_data(). Then, implement getting the property's value as a Variable block with _drop_obj_property() in detail.

And, if the modifier CTRL key is pressed, then drop a setting the property's value block.

https://phabricator.endlessm.com/T35649