### PR TITLE
Fix uid conflict in example ball scenes

### DIFF
--- a/addons/block_code/examples/pong_game/ball.tscn
+++ b/addons/block_code/examples/pong_game/ball.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=3 uid="uid://c7l70grmkauij"]
+[gd_scene load_steps=4 format=3 uid="uid://c7l70grmkauij"]
 
 [ext_resource type="Texture2D" uid="uid://bcgr5amsq3jfl" path="res://addons/block_code/examples/pong_game/assets/ball.png" id="2_xkrmm"]
 
@@ -14,8 +14,8 @@ collision_layer = 2
 collision_mask = 15
 physics_material_override = SubResource("PhysicsMaterial_c3m63")
 continuous_cd = 1
-max_contacts_reported = 1
 contact_monitor = true
+max_contacts_reported = 1
 linear_velocity = Vector2(353.553, 353.553)
 linear_damp_mode = 1
 angular_damp_mode = 1

--- a/addons/block_code/examples/pong_game/pong_game.tscn
+++ b/addons/block_code/examples/pong_game/pong_game.tscn
@@ -9,7 +9,7 @@
 [ext_resource type="Script" path="res://addons/block_code/code_generation/option_data.gd" id="7_3q6bj"]
 [ext_resource type="Script" path="res://addons/block_code/serialization/block_script_serialization.gd" id="7_uuuue"]
 [ext_resource type="Script" path="res://addons/block_code/code_generation/variable_definition.gd" id="9_lo3p1"]
-[ext_resource type="PackedScene" uid="uid://c7l70grmkauij" path="res://addons/block_code/examples/spawner/ball.tscn" id="9_xrqll"]
+[ext_resource type="PackedScene" uid="uid://c7l70grmkauij" path="res://addons/block_code/examples/pong_game/ball.tscn" id="9_xrqll"]
 [ext_resource type="Script" path="res://addons/block_code/serialization/value_block_serialization.gd" id="11_yafka"]
 [ext_resource type="PackedScene" uid="uid://fhoapg3anjsu" path="res://addons/block_code/examples/pong_game/goal_area.tscn" id="12_nqmxu"]
 [ext_resource type="PackedScene" uid="uid://djmtbm15n2wqq" path="res://addons/block_code/examples/pong_game/player_score.tscn" id="13_jvkp7"]

--- a/addons/block_code/examples/spawner/ball.tscn
+++ b/addons/block_code/examples/spawner/ball.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=4 format=3 uid="uid://c7l70grmkauij"]
+[gd_scene load_steps=4 format=3 uid="uid://dhfvkunrlqads"]
 
 [ext_resource type="Texture2D" uid="uid://bcgr5amsq3jfl" path="res://addons/block_code/examples/pong_game/assets/ball.png" id="2_xkrmm"]
 

--- a/addons/block_code/examples/spawner/spawner.tscn
+++ b/addons/block_code/examples/spawner/spawner.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=37 format=3 uid="uid://cbgxxdewi6gld"]
 
 [ext_resource type="Script" path="res://addons/block_code/simple_spawner/simple_spawner.gd" id="1_g2l2s"]
-[ext_resource type="PackedScene" uid="uid://c7l70grmkauij" path="res://addons/block_code/examples/spawner/ball.tscn" id="2_d0h86"]
+[ext_resource type="PackedScene" uid="uid://dhfvkunrlqads" path="res://addons/block_code/examples/spawner/ball.tscn" id="2_d0h86"]
 [ext_resource type="PackedScene" uid="uid://c8hrliwojohal" path="res://addons/block_code/examples/spawner/volatile_ball.tscn" id="3_tt12o"]
 [ext_resource type="Script" path="res://addons/block_code/block_code_node/block_code.gd" id="4_e0fbh"]
 [ext_resource type="Script" path="res://addons/block_code/serialization/block_serialization_tree.gd" id="5_g4h7g"]


### PR DESCRIPTION
Godot 4.4 warns about UID conflicts between these scenes. It seems the scene was copied on the filesystem rather than using the editor's save as functionality, which generates new UIDs. This is also how pong started using the spawner ball scene. Likely the spawner example should just use the pong ball scene, but this makes them independent.