### PR TITLE
Run tests with Godot 4.4 prerelease

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -34,6 +34,7 @@ jobs:
       matrix:
         godot-version:
           - 4.3.0
+          - 4.4.0-dev7
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
This is potentially interesting because we have translation-related code
that behaves differently between 4.4 (which has some new API) and older
versions (which do not).