### PR TITLE
Translation scripts

### DIFF
--- a/addons/block_code/README.md
+++ b/addons/block_code/README.md
@@ -99,13 +99,8 @@ up to date.
   shell script.
 
 * If the POT file has changed, the PO message files need to be updated. This
-  can be done using the gettext `msgmerge` tool in the
-  `addons/block_code/locale` directory:
-  ```
-  for po in *.po; do
-    msgmerge --update --backup=none "$po" godot_block_coding.pot
-  done
-  ```
+  can be done using the gettext `msgmerge` tool with the
+  `scripts/merge-messages.sh` shell script.
 
 [pot-generation]: https://docs.godotengine.org/en/stable/tutorials/i18n/localization_using_gettext.html#automatic-generation-using-the-editor
 

--- a/addons/block_code/README.md
+++ b/addons/block_code/README.md
@@ -92,7 +92,9 @@ up to date.
 * If translatable strings have changed, the POT file needs to be updated. This
   can be done by using the **Generate POT** dialog in the [POT
   Generation][pot-generation] tab. Or you can use the **Project → Tools →
-  Regenerate BlockCode POT file** menu item in the editor.
+  Regenerate BlockCode POT file** menu item in the editor. From the command
+  line, the POT file can be regenerated with the `scripts/regenerate-pot.sh`
+  shell script.
 
 * If the POT file has changed, the PO message files need to be updated. This
   can be done using the gettext `msgmerge` tool in the

--- a/addons/block_code/README.md
+++ b/addons/block_code/README.md
@@ -87,7 +87,9 @@ up to date.
 * If files are added or removed, the list of translatable files needs to be
   updated. This can be done by using the **Add** dialog in the [POT
   Generation][pot-generation] tab. Or you can use the **Project → Tools →
-  Update BlockCode translated files** menu item in the editor.
+  Update BlockCode translated files** menu item in the editor. From the command
+  line, the POT file can be regenerated with the `scripts/update-pot-files.sh`
+  shell script.
 
 * If translatable strings have changed, the POT file needs to be updated. This
   can be done by using the **Generate POT** dialog in the [POT

--- a/scripts/godot.sh
+++ b/scripts/godot.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Wrapper script to try to execute the Godot binary.
+set -e
+
+get_godot_bin() {
+    # GODOT environment variable preferred.
+    if [ -n "$GODOT" ]; then
+        echo "$GODOT"
+        return 0
+    fi
+
+    # godot in PATH.
+    if type -p godot >/dev/null; then
+        echo godot
+        return 0
+    fi
+
+    # Flatpak Godot with <installation>/exports/bin in PATH.
+    if type -p org.godotengine.Godot >/dev/null; then
+        echo org.godotengine.Godot
+        return 0
+    fi
+
+    # Flatpak Godot without <installation>/exports/bin in PATH.
+    if flatpak info org.godotengine.Godot &>/dev/null; then
+        echo "flatpak run org.godotengine.Godot"
+        return 0
+    fi
+
+    echo "error: Could not find godot executable, set GODOT environment variable" >&2
+    return 1
+}
+
+godot_bin=$(get_godot_bin)
+exec $godot_bin "$@"

--- a/scripts/merge-messages.sh
+++ b/scripts/merge-messages.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Merge new strings from POT file into message catalogs.
+set -e
+
+SCRIPTDIR=$(dirname "$0")
+PROJDIR=$(dirname "$SCRIPTDIR")
+LOCALEDIR="$PROJDIR/addons/block_code/locale"
+POT="$LOCALEDIR/godot_block_coding.pot"
+
+for po in "$LOCALEDIR"/*.po; do
+    echo -n "$po"
+    msgmerge --update --backup=none "$po" "$POT"
+done

--- a/scripts/regenerate-pot.gd
+++ b/scripts/regenerate-pot.gd
@@ -1,0 +1,25 @@
+## BlockCode POT regeneration script
+##
+## Use this on the Godot command line with the --script option. This depends on
+## the Godot editor, so the --editor option is also required.
+extends SceneTree
+
+const TxUtils := preload("res://addons/block_code/translation/utils.gd")
+
+
+# Everything happens in _process to ensure the editor is fully initialized.
+func _process(_delta):
+	if Engine.is_editor_hint():
+		TxUtils.regenerate_pot_file()
+	else:
+		push_error("%s can only be run with --editor" % get_script().resource_path)
+
+	# Stop processing the main loop.
+	return true
+
+
+# The editor won't be shut down in the normal way, which will cause a bunch of
+# leaks. There's nothing we can do about that and we don't care about them,
+# anyways. Let the user following along know this is OK.
+func _finalize():
+	print_rich("[b]%s causes Godot to leak resources. Ignore the warnings and errors![/b]" % get_script().resource_path.get_file())

--- a/scripts/regenerate-pot.sh
+++ b/scripts/regenerate-pot.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Wrapper script to try to execute the regenerate-pot.gd main loop script.
+set -e
+
+SCRIPTDIR=$(dirname "$0")
+PROJDIR=$(dirname "$SCRIPTDIR")
+GODOT_SH="$SCRIPTDIR/godot.sh"
+SCRIPT="$SCRIPTDIR/regenerate-pot.gd"
+
+exec "$GODOT_SH" --path "$PROJDIR" --headless --editor --script "$SCRIPT"

--- a/scripts/update-pot-files.gd
+++ b/scripts/update-pot-files.gd
@@ -1,0 +1,11 @@
+## BlockCode update translated files script
+##
+## Use this on the Godot command line with the --script option.
+extends SceneTree
+
+const TxUtils := preload("res://addons/block_code/translation/utils.gd")
+
+
+func _init():
+	TxUtils.update_pot_files()
+	quit()

--- a/scripts/update-pot-files.sh
+++ b/scripts/update-pot-files.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Wrapper script to try to execute the update-pot-files.gd main loop script.
+set -e
+
+SCRIPTDIR=$(dirname "$0")
+PROJDIR=$(dirname "$SCRIPTDIR")
+GODOT_SH="$SCRIPTDIR/godot.sh"
+SCRIPT="$SCRIPTDIR/update-pot-files.gd"
+
+exec "$GODOT_SH" --path "$PROJDIR" --headless --script "$SCRIPT"


### PR DESCRIPTION
CLI script for updating translations. The `regenerate-pot.gd` script is pretty nasty since it has to with for the editor before poking at the UI. The others are pretty straightforward. I wasn't sure if we wanted to add GitHub workflows for these or not.

https://phabricator.endlessm.com/T35705