### PR TITLE
Fix "Type::" double colon in block tooltip

### DIFF
--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -221,7 +221,7 @@ func _get_tooltip(at_position: Vector2) -> String:
 	if definition.variant_type == Variant.Type.TYPE_NIL:
 		return description_tx
 
-	return "{description}\n\n{type_field}: [b]{type}[/b]".format({"description": description_tx, "type_field": tr("Type:"), "type": type_string(definition.variant_type)})
+	return "{description}\n\n{type_field} [b]{type}[/b]".format({"description": description_tx, "type_field": tr("Type:"), "type": type_string(definition.variant_type)})
 
 
 func _make_custom_tooltip(for_text) -> Control:


### PR DESCRIPTION
In commit 3e208d75ccb761d936b3126082407632dc09d7ec, the string "Type:" was extracted from the template string to be translated separately, including The colon. It is correct for the colon to be part of the translatable string, because (for example) in French there must be a non-breaking space between the word and the colon.

However, there was also a stray colon in the template string. Remove it.