### PR TITLE
/claim #257

### DIFF
--- a/addons/block_code/simple_nodes/simple_character/simple_character.gd
+++ b/addons/block_code/simple_nodes/simple_character/simple_character.gd
@@ -101,15 +101,15 @@ func _player_input_to_direction(player: String):
 
 	# Gamepad input (new)
 	if player == "player_1" or player == "player_2":
-		var joy_index = 0 if player == "player_1" else 1 # Assuming player 1 uses the first gamepad and player 2 uses the second
+		var joy_index = 0 if player == "player_1" else 1  # Assuming player 1 uses the first gamepad and player 2 uses the second
 		# Horizontal movement (left stick x-axis)
-		direction.x += Input.get_joy_axis(joy_index, JOY_AXIS_0) # Left stick X-axis
+		direction.x += Input.get_joy_axis(joy_index, JOY_AXIS_0)  # Left stick X-axis
 		# Vertical movement (left stick y-axis)
-		direction.y += Input.get_joy_axis(joy_index, JOY_AXIS_1) # Left stick Y-axis
+		direction.y += Input.get_joy_axis(joy_index, JOY_AXIS_1)  # Left stick Y-axis
 
 		# You can also check for specific gamepad button presses if needed
 		# For example, A button for jumping (Button 0) on player 1 and player 2
-		if Input.is_joy_button_pressed(joy_index, JOY_BUTTON_0): # Button 0 (A button on most controllers)
+		if Input.is_joy_button_pressed(joy_index, JOY_BUTTON_0):  # Button 0 (A button on most controllers)
 			# Handle button press (for jumping or other actions)
 			pass
 
@@ -148,7 +148,6 @@ func move_with_player_buttons(player: String, kind: String, delta: float, input_
 	move_and_slide()
 
 
-
 static func setup_custom_blocks():
 	var _class_name = "SimpleCharacter"
 	var block_list: Array[BlockDefinition] = []
@@ -161,23 +160,21 @@ static func setup_custom_blocks():
 	block_definition.type = Types.BlockType.STATEMENT
 	block_definition.display_template = "move with {player: NIL} buttons as {kind: NIL} using {input_type: NIL}"
 	block_definition.description = """Move the character using the configured controls. You can select between keyboard or gamepad for the input.
-	
+
 	“Top-down” enables the character to move in both x (horizontal) and y (vertical) dimensions, like a top-down view.
-	
+
 	“Platformer” enables the character to move as in a side-scroller, with gravity affecting vertical movement.
-	
+
 	“Spaceship” uses the left/right controls to rotate and up/down controls to move forward or backward."""
-	
+
 	# Updated code template to include input type
 	block_definition.code_template = "move_with_player_buttons({player}, {kind}, delta, {input_type})"
-	
+
 	# Add new input type option (keyboard or gamepad)
 	block_definition.defaults = {
-		"player": OptionData.new(["player_1", "player_2"]),
-		"kind": OptionData.new(["top-down", "platformer", "spaceship"]),
-		"input_type": OptionData.new(["keyboard", "gamepad"])  # Add gamepad option
+		"player": OptionData.new(["player_1", "player_2"]), "kind": OptionData.new(["top-down", "platformer", "spaceship"]), "input_type": OptionData.new(["keyboard", "gamepad"])  # Add gamepad option
 	}
-	
+
 	# Add block definition to the block list
 	block_list.append(block_definition)
 
@@ -205,5 +202,4 @@ static func setup_custom_blocks():
 		},
 	}
 
-	// Add custom blocks to the catalog
 	BlocksCatalog.add_custom_blocks(_class_name, block_list, property_list, property_settings)


### PR DESCRIPTION
/claim #257
 Problem Overview
The "Move with Player 1/2" block currently only works with keyboard inputs (e.g., WASD keys and arrow keys).
The goal is to extend this functionality so that the block can also work with gamepad inputs (such as analog stick movements or D-pad buttons) to allow for more flexible control options, especially for users who prefer using a gamepad.
2. Solution Overview
The solution likely involves modifying the existing block logic to incorporate gamepad support. Here's how that could have been done:

Input Type Handling: A new input_type parameter or method is added, which allows the system to determine whether the inputs should come from the keyboard or gamepad.
Gamepad Input Mapping: The standard Godot input system can be used to map gamepad buttons and analog stick movements. In Godot, the Input class can be used to detect gamepad inputs, such as:
D-pad or Analog Stick: Detect movement from the analog sticks or D-pad.
Gamepad Buttons: Detect button presses (e.g., A, B, X, Y on controllers).
Controller Input Logic: The code in the move_with_player_buttons method would be updated to check for gamepad inputs in addition to keyboard inputs, possibly by using Input.get_joy_axis() for joystick movement or Input.is_joy_button_pressed() for button presses.