### PR TITLE
Set Godot 4.3 as minimum supported version

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -33,7 +33,6 @@ jobs:
     strategy:
       matrix:
         godot-version:
-          - 4.2.2
           - 4.3.0
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -32,7 +32,9 @@ jobs:
     name: Tests
     strategy:
       matrix:
-        godot-version: [4.2.2, 4.3.0]
+        godot-version:
+          - 4.2.2
+          - 4.3.0
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/addons/block_code/simple_spawner/simple_spawner.gd
+++ b/addons/block_code/simple_spawner/simple_spawner.gd
@@ -89,7 +89,7 @@ func spawn_once():
 	if scenes.size() == 0:
 		return
 
-	_spawned_scenes = _spawned_scenes.filter(func(instance): return is_instance_valid(instance))
+	_spawned_scenes = _spawned_scenes.filter(is_instance_valid)
 
 	if spawn_limit != 0 and _spawned_scenes.size() >= spawn_limit:
 		if limit_behavior == LimitBehavior.NO_SPAWN:

--- a/addons/block_code/ui/block_canvas/block_canvas.gd
+++ b/addons/block_code/ui/block_canvas/block_canvas.gd
@@ -67,7 +67,7 @@ signal replace_block_code
 func _ready():
 	_context.changed.connect(_on_context_changed)
 
-	if not _open_scene_button.icon and not Util.node_is_part_of_edited_scene(self):
+	if not _open_scene_button.icon and not self.is_part_of_edited_scene():
 		_open_scene_button.icon = _open_scene_icon
 	if not _zoom_out_button.icon:
 		_zoom_out_button.icon = _icon_zoom_out
@@ -99,7 +99,7 @@ func _can_drop_data(at_position: Vector2, data: Variant) -> bool:
 	# Don't allow dropping BlockCode nodes or nodes that aren't part of the
 	# edited scene.
 	var node := get_tree().root.get_node(abs_path)
-	if node is BlockCode or not Util.node_is_part_of_edited_scene(node):
+	if node is BlockCode or not node.is_part_of_edited_scene():
 		return false
 
 	# Don't allow dropping the BlockCode node's parent as that's already self.

--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -132,10 +132,7 @@ func _get_parameter_defaults() -> Dictionary:
 	if not block_extension:
 		return definition.defaults
 
-	# Use Dictionary.merge instead of Dictionary.merged for Godot 4.2 compatibility
-	var new_defaults := block_extension.get_defaults()
-	new_defaults.merge(definition.defaults)
-	return new_defaults
+	return block_extension.get_defaults().merged(definition.defaults)
 
 
 func _get_or_create_block_extension() -> BlockExtension:

--- a/addons/block_code/ui/picker/categories/block_category_button.gd
+++ b/addons/block_code/ui/picker/categories/block_category_button.gd
@@ -16,7 +16,7 @@ func _ready():
 	if not category:
 		category = BlockCategory.new("Example", Color.RED)
 
-	if not Util.node_is_part_of_edited_scene(self):
+	if not self.is_part_of_edited_scene():
 		var new_stylebox: StyleBoxFlat = _panel.get_theme_stylebox("panel").duplicate()
 		new_stylebox.bg_color = category.color
 		_panel.add_theme_stylebox_override("panel", new_stylebox)

--- a/addons/block_code/ui/tooltip/tooltip.gd
+++ b/addons/block_code/ui/tooltip/tooltip.gd
@@ -27,5 +27,5 @@ func override_fonts():
 
 
 func _ready():
-	if not Util.node_is_part_of_edited_scene(self):
+	if not self.is_part_of_edited_scene():
 		override_fonts()

--- a/addons/block_code/ui/util.gd
+++ b/addons/block_code/ui/util.gd
@@ -1,19 +1,6 @@
 extends Object
 
 
-## Polyfill of Node.is_part_of_edited_scene(), available to GDScript in Godot 4.3+.
-static func node_is_part_of_edited_scene(node: Node) -> bool:
-	if not Engine.is_editor_hint():
-		return false
-
-	var tree := node.get_tree()
-	if not tree or not tree.edited_scene_root:
-		return false
-
-	var edited_scene_parent := tree.edited_scene_root.get_parent()
-	return edited_scene_parent and edited_scene_parent.is_ancestor_of(node)
-
-
 ## Get the path from [param reference] to [param node] within a scene.
 ##
 ## Returns the path from [param reference] to [param node] without referencing

--- a/asset-template.json.hb
+++ b/asset-template.json.hb
@@ -2,7 +2,7 @@
   "title": "Block Coding",
   "description": "Create games using a high-level, block-based visual programming language.\r\n\r\nIntended as an educational tool for learners in the earlier stages of their journey towards becoming game developers. This plugin lets you create your first games with high-level blocks, avoiding the immediate need to learn to code in GDScript. Building games in this way provides a gentle introduction to programming concepts and allows you to focus your efforts on becoming familiar with the rest of the Godot Editor UI.",
   "category_id": "5",
-  "godot_version": "4.2",
+  "godot_version": "4.3",
   "version_string": "{{ context.release.name }}",
   "cost": "MIT",
   "support_level": "community",


### PR DESCRIPTION
Godot 4.3 has been available for 4 months and it seems unlikely that anyone will have a pressing need to add blocks to a Godot 4.2 project.

Although we have been running unit tests against 4.2 in CI, those do not cover the full functionality of the plugin. To the best of my knowledge, no-one is regularly testing the plugin interactively against Godot 4.2.

Set the minimum version in the asset library template. Drop 4.2 from the CI test matrix. Remove some workarounds for 4.2 compatibility.