### PR TITLE
Warn when Block Code overrides parent script

### DIFF
--- a/addons/block_code/block_code_node/block_code.gd
+++ b/addons/block_code/block_code_node/block_code.gd
@@ -84,6 +84,8 @@ func _get_configuration_warnings():
 		warnings.append("A BlockCode must not be a root node.")
 	if get_parent() is BlockCode:
 		warnings.append("The parent must not be a BlockCode.")
+	if get_parent().script:
+		warnings.append("This BlockCode will override the existing script in the parent node.")
 	if get_parent().find_children("*", "BlockCode", false).size() > 1:
 		warnings.append("The parent should only contain one BlockCode.")
 	if block_script and _get_custom_or_native_class(get_parent()) != block_script.script_inherits:


### PR DESCRIPTION
Add a warning when the parent node of a BlockCoding node already has a script. To inform the user.

Fix https://github.com/endlessm/godot-block-coding/issues/356