### PR TITLE
Make blocks in Picker not editable

### DIFF
--- a/addons/block_code/drag_manager/drag_manager.gd
+++ b/addons/block_code/drag_manager/drag_manager.gd
@@ -82,8 +82,9 @@ func drag_ended():
 		connect_block_canvas_signals(block)
 		block.grab_focus()
 
-		# Allow the block to be deleted now that it's on the canvas.
+		# Allow the block to be deleted and edited now that it's on the canvas.
 		block.can_delete = true
+		block.editable = true
 
 	_block_canvas.release_scope()
 

--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -10,6 +10,10 @@ signal modified
 ## Color of block (optionally used to draw block color)
 @export var color: Color = Color(1., 1., 1.)
 
+## Whether the parameter inputs inside the block can be edited.
+@export var editable: bool = true:
+	set = _set_editable
+
 # FIXME Note: This used to be a NodePath. There is a bug in Godot 4.2 that causes the
 # reference to not be set properly when the node is duplicated. Since we don't
 # use the Node duplicate function anymore, this is okay.
@@ -54,6 +58,11 @@ func _ready():
 	focus_entered.connect(_block_on_focus_entered)
 	focus_exited.connect(_block_on_focus_exited)
 	_on_definition_changed()
+
+
+func _set_editable(value) -> void:
+	editable = value
+	template_editor.editable = value
 
 
 func _block_on_focus_entered():

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
@@ -56,6 +56,22 @@ var _drag_start: Vector2 = Vector2.INF
 	_v3_z_line_edit: "",
 }
 
+## Whether the text inputs can be edited, and whether the options selection have any effect.
+@export var editable: bool = true:
+	set = _set_editable
+
+
+func _set_editable(value) -> void:
+	if not is_node_ready():
+		await ready
+	editable = value
+	_line_edit.editable = value
+	_x_line_edit.editable = value
+	_y_line_edit.editable = value
+	_v3_x_line_edit.editable = value
+	_v3_y_line_edit.editable = value
+	_v3_z_line_edit.editable = value
+
 
 ## Sets the value using [param raw_input], which could be one of a variety of types
 ## depending on [member variant_type]. The value could also be a [Block], in which
@@ -180,6 +196,8 @@ func get_snapped_block() -> Block:
 
 
 func _validate_and_submit_edit_text(line_edit: Node, type: Variant.Type):
+	if not editable:
+		return
 	if _last_submitted_text[line_edit] == line_edit.text:
 		return
 	match type:
@@ -319,6 +337,8 @@ func _update_option_input(current_value: Variant = null):
 
 
 func _on_color_input_color_changed(color):
+	if not editable:
+		return
 	_update_background_color(color)
 	modified.emit()
 
@@ -328,6 +348,8 @@ func _update_background_color(new_color):
 
 
 func _on_option_input_item_selected(index):
+	if not editable:
+		return
 	modified.emit()
 
 

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn
@@ -34,6 +34,7 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("1_rgmxn")
+editable = null
 
 [node name="Background" type="Control" parent="."]
 unique_name_in_owner = true

--- a/addons/block_code/ui/blocks/utilities/template_editor/template_editor.gd
+++ b/addons/block_code/ui/blocks/utilities/template_editor/template_editor.gd
@@ -36,6 +36,10 @@ const CollapsableSettingsScene = preload("res://addons/block_code/ui/blocks/util
 		parameter_defaults = value
 		_update_from_format_string()
 
+## Whether the parameter inputs can be edited.
+@export var editable: bool = true:
+	set = _set_editable
+
 var parent_block: Block
 var _parameter_inputs_by_name: Dictionary
 
@@ -46,6 +50,13 @@ func _ready() -> void:
 	parent_block = BlockTreeUtil.get_parent_block(self)
 
 	_update_from_format_string()
+
+
+func _set_editable(value) -> void:
+	editable = value
+	for parameter_name in _parameter_inputs_by_name:
+		var parameter_input: ParameterInput = _parameter_inputs_by_name[parameter_name]
+		parameter_input.editable = value
 
 
 ## Set the values of all input parameters based from a dictionary of raw values.
@@ -125,6 +136,7 @@ func _append_input_parameter(container: Container, parameter: Dictionary, id: in
 	parameter_input.placeholder = parameter["name"]
 	parameter_input.variant_type = parameter["type"]
 	parameter_input.drag_started.connect(_on_parameter_input_drag_started)
+	parameter_input.editable = editable
 
 	if default_value is OptionData:
 		var option_data := default_value as OptionData

--- a/addons/block_code/ui/blocks/utilities/template_editor/template_editor.tscn
+++ b/addons/block_code/ui/blocks/utilities/template_editor/template_editor.tscn
@@ -10,6 +10,7 @@ grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
 script = ExtResource("1_7extq")
+editable = null
 
 [node name="Container" type="HBoxContainer" parent="."]
 unique_name_in_owner = true

--- a/addons/block_code/ui/picker/categories/block_category_display.gd
+++ b/addons/block_code/ui/picker/categories/block_category_display.gd
@@ -66,6 +66,7 @@ func _get_or_create_block(block_definition: BlockDefinition) -> Block:
 	if block == null:
 		block = _context.block_script.instantiate_block(block_definition)
 		block.can_delete = false
+		block.editable = false
 		block.drag_started.connect(func(block: Block, offset: Vector2): block_picked.emit(block, offset))
 		_blocks_container.add_child(block)
 		_blocks[block_definition.name] = block


### PR DESCRIPTION
Add a new "editable" boolean property to Block, TemplateEditor and ParameterInput. When the block is in the picker, it will not be editable. Only when they are dragged to the canvas they become editable.

The property has to be in each of these components because Block can't access its ParameterInputs directly, only through its TemplateEditor.

The dropdown options in a not-editable block can still be changed to avoid disabling the button. But the change doesn't trigger any effect.

The default is editable = true, so blocks in the canvas are editable.

Fix https://github.com/endlessm/godot-block-coding/issues/357