### PR TITLE
Don't warn when BlockCode script extends parent script

### DIFF
--- a/addons/block_code/block_code_node/block_code.gd
+++ b/addons/block_code/block_code_node/block_code.gd
@@ -85,7 +85,9 @@ func _get_configuration_warnings():
 	if get_parent() is BlockCode:
 		warnings.append("The parent must not be a BlockCode.")
 	if get_parent().script:
-		warnings.append("This BlockCode will override the existing script in the parent node.")
+		var parent_script_name: StringName = get_parent().script.get_global_name()
+		if not (parent_script_name and block_script and parent_script_name == block_script.script_inherits):
+			warnings.append("This BlockCode will override the existing script in the parent node.")
 	if get_parent().find_children("*", "BlockCode", false).size() > 1:
 		warnings.append("The parent should only contain one BlockCode.")
 	if block_script and _get_custom_or_native_class(get_parent()) != block_script.script_inherits:


### PR DESCRIPTION
Commit 87c31b05c9f720cc2512285340117b86afc94e8e ("Warn when Block Code overrides parent script") introduced a warning when a BlockCode node's parent has a script attached. But if the parent is (for example) a Character2D with our SimpleCharacter script attached, this warning is incorrect: the block code script will correctly extend, not override, the parent.

Before issuing this warning, check if the parent's script has a class_name that matches what the generated BlockCode script will extend, and suppress the warning if so.

Fixes https://github.com/endlessm/godot-block-coding/issues/356