### PR TITLE
Set window stretch mode to "canvas_items"

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://addons/block_code/examples/pong_game/pong_game.tscn"
 config/features=PackedStringArray("4.3", "GL Compatibility")
 config/icon="res://icon.svg"
 
+[display]
+
+window/stretch/mode="canvas_items"
+
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/block_code/plugin.cfg", "res://addons/gut/plugin.cfg", "res://addons/plugin_refresher/plugin.cfg")


### PR DESCRIPTION
This reverts the window stretch mode to what it was before a5444c59 . The Pong example is still the main scene, and the example can be cropped if this setting is the default.