### PR TITLE
Block: Translate property only if possible

### DIFF
--- a/addons/block_code/ui/blocks/block/block.gd
+++ b/addons/block_code/ui/blocks/block/block.gd
@@ -129,7 +129,7 @@ func _get_format_string() -> String:
 	if not definition:
 		return ""
 
-	if definition.property_name:
+	if definition.property_name and TranslationServer.has_method(&"get_or_add_domain"):
 		var domain: TranslationDomain = TranslationServer.get_or_add_domain("godot.properties")
 		var translated_property: String = domain.translate(definition.property_name.capitalize())
 		# TODO: Ideally we should be also passing the context. See:


### PR DESCRIPTION
The TranslationServer.get_or_add_domain() method was added in Godot 4.4, but the addon may still work in Godot 4.3 if we disable property translations when the method isn't present.

https://github.com/endlessm/godot-block-coding/discussions/397