### PR TITLE
Repopulate variable code template

### DIFF
--- a/addons/block_code/code_generation/block_definition.gd
+++ b/addons/block_code/code_generation/block_definition.gd
@@ -289,6 +289,6 @@ static func new_variable_getter(variable: VariableDefinition) -> Resource:
 		Types.BlockType.VALUE,
 		variable.var_type,
 		"%s" % variable.var_name,
-		"%s",
+		"%s" % variable.var_name,
 	)
 	return block_definition


### PR DESCRIPTION
Looks like a simple writing mistake!

Fix for https://github.com/endlessm/godot-block-coding/issues/400
Caused by [947bd28](https://github.com/endlessm/godot-block-coding/commit/947bd28888551a91fff86ee0ad0506eb27335109)