### PR TITLE
Adds to_string block with optional types

### DIFF
--- a/addons/block_code/blocks/log/to_string.tres
+++ b/addons/block_code/blocks/log/to_string.tres
@@ -1,0 +1,25 @@
+[gd_resource type="Resource" load_steps=4 format=3 uid="uid://bfugvntm6mdjm"]
+
+[ext_resource type="Script" uid="uid://bkapmk0btnk7y" path="res://addons/block_code/code_generation/option_data.gd" id="1_i1nej"]
+[ext_resource type="Script" uid="uid://bau6qtv87fcdo" path="res://addons/block_code/code_generation/block_definition.gd" id="2_xs7a8"]
+
+[sub_resource type="Resource" id="Resource_ie4sg"]
+script = ExtResource("1_i1nej")
+selected = 0
+items = ["0", "true", "Vector2(0, 0)", "Vector3(0, 0, 0)", "Color(0, 0, 0, 1)", "Object(Object, \"script\": null)"]
+
+[resource]
+script = ExtResource("2_xs7a8")
+name = &"to_string"
+target_node_class = ""
+description = "Converts [i]parameter[/i] to a [b]String[/b]"
+category = "Log"
+type = 3
+variant_type = 4
+display_template = "{parameter: NIL} to string"
+code_template = "str({{parameter}})"
+defaults = {
+"parameter": SubResource("Resource_ie4sg")
+}
+signal_name = ""
+is_advanced = true

--- a/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
+++ b/addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.gd
@@ -6,6 +6,7 @@ signal drag_started(offset: Vector2)
 const Constants = preload("res://addons/block_code/ui/constants.gd")
 const OptionData = preload("res://addons/block_code/code_generation/option_data.gd")
 const Types = preload("res://addons/block_code/types/types.gd")
+const Option_Theme = preload("res://addons/block_code/ui/blocks/utilities/parameter_input/parameter_input.tscn::StyleBoxFlat_7m75r")
 
 signal modified
 
@@ -286,6 +287,24 @@ func _switch_input(node: Node):
 		c.visible = c == node
 	_background.visible = node not in [_option_input, null]
 	_background.is_pointy_value = node == _bool_input
+	if option_data:
+		_option_input.add_theme_stylebox_override("focus", Option_Theme)
+		_option_input.add_theme_stylebox_override("hover", Option_Theme)
+		_option_input.add_theme_stylebox_override("pressed", Option_Theme)
+		_option_input.add_theme_stylebox_override("normal", Option_Theme)
+		var raw_input = get_raw_input()
+		var data = str_to_var("" if raw_input == null or raw_input is Block else raw_input)
+		if typeof(data):
+			var empty_theme = StyleBoxEmpty.new()
+			_option_input.add_theme_stylebox_override("focus", empty_theme)
+			_option_input.add_theme_stylebox_override("hover", empty_theme)
+			_option_input.add_theme_stylebox_override("pressed", empty_theme)
+			_option_input.add_theme_stylebox_override("normal", empty_theme)
+			variant_type = typeof(data)
+			_background.visible = true
+			_background.is_pointy_value = variant_type == TYPE_BOOL
+			snap_point.visible = true
+			snap_point.variant_type = variant_type
 
 
 func _update_option_input(current_value: Variant = null):
@@ -350,6 +369,7 @@ func _update_background_color(new_color):
 func _on_option_input_item_selected(index):
 	if not editable:
 		return
+	_update_visible_input()
 	modified.emit()
 
 


### PR DESCRIPTION
Partially addresses #351

The to_string block converts a parameter to a string. It includes an option input with an integer, a boolean, a vector2, a vector3, a color, and an object.

The type of the selected input gets detected and displays as a normal parameter input with the detected type and snapping
<img width="349" height="550" alt="example" src="https://github.com/user-attachments/assets/70f47f8f-9bcb-493a-a8f2-682ec102bc26" />

This prints:
```
4.0
false
(0.0, 0.0)
(1.0, 1.0, 1.0, 1.0)
Sprite2D:<Sprite2D#59659781447>
```
